### PR TITLE
Add note to readme about benchmark acceptance

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Each benchmark consists of:
 
 After these files are created, they must be added to `scenarioConfig` in `scripts/src/generateMatrix.ts` to be run in CI.
 
-> [!NOTE]  
+> [!NOTE]\
 > Benchmark capacity is limited; we may not accept all benchmarks or run them automatically in CI.
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ Each benchmark consists of:
 
 After these files are created, they must be added to `scenarioConfig` in `scripts/src/generateMatrix.ts` to be run in CI.
 
+> [!NOTE]  
+> Benchmark capacity is limited; we may not accept all benchmarks or run them automatically in CI.
+
 ## Contributing
 
 This project welcomes contributions and suggestions. Most contributions require you to agree to a

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Each benchmark consists of:
 
 After these files are created, they must be added to `scenarioConfig` in `scripts/src/generateMatrix.ts` to be run in CI.
 
-> [!NOTE]\
+> [!NOTE]
 > Benchmark capacity is limited; we may not accept all benchmarks or run them automatically in CI.
 
 ## Contributing


### PR DESCRIPTION
Hopefully temporary-ish?

This special syntax looks like:

![image](https://github.com/microsoft/typescript-benchmarking/assets/5341706/52bbdb04-a5da-4f3d-9398-42fbcf84616b)
