### PR TITLE
Define kind sorting to put tsc first

### DIFF
--- a/scripts/src/generateMatrix.ts
+++ b/scripts/src/generateMatrix.ts
@@ -1,3 +1,5 @@
+import assert from "node:assert";
+
 import minimist from "minimist";
 
 import { setOutputVariable } from "./utils.js";
@@ -236,8 +238,13 @@ for (const [agent, value] of Object.entries(matrix)) {
     console.log(JSON.stringify(value, undefined, 4));
 }
 
+// This defines the sort order, which is seen in PR replies; tsc is the most important and should be first.
+const kindOrder: readonly JobKind[] = ["tsc", "tsserver", "startup"];
+
+assert.deepStrictEqual([...allJobKinds].sort(), [...kindOrder].sort(), "kindOrder must contain all job kinds");
+
 // These are outputs for the ProcessResults job, specifying which results were
 // produced previously and need to be processed. This is a space separated list,
 // iterated in the pipeline in bash.
-setOutputVariable(`TSPERF_PROCESS_KINDS`, [...processKinds].sort().join(" "));
+setOutputVariable(`TSPERF_PROCESS_KINDS`, kindOrder.filter(kind => processKinds.has(kind)).join(" "));
 setOutputVariable(`TSPERF_PROCESS_LOCATIONS`, [...processLocations].sort().join(","));


### PR DESCRIPTION
After deduplicating a bunch of stuff using the "kind" as the parameter to many elements of the pipeline, the PR comments now say "tsc" instead of "compiler", and display results in a plain `.sort()` order. This meant we'd display "startup" benchmarks before "tsc" benchmarks, but we definitely want those first.