### PR TITLE
Test and baseline generateMatrix

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -23,7 +23,8 @@
     ],
     "ignorePatterns": [
         "**/node_modules/**",
-        "**/dist/**"
+        "**/dist/**",
+        "/vitest.workspace.mjs"
     ],
     "rules": {
         // eslint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,3 +69,29 @@ jobs:
           run_install: true
 
       - run: pnpm dprint check
+
+  required:
+    runs-on: ubuntu-latest
+    if: ${{ always() }}
+    needs:
+      - build
+      - test
+      - lint
+      - format
+
+    steps:
+      - name: Check required jobs
+        run: |
+          results=(
+            "${{ needs.build.result }}"
+            "${{ needs.test.result }}"
+            "${{ needs.lint.result }}"
+            "${{ needs.format.result }}"
+          )
+
+          for result in "${results[@]}"; do
+            if [[ "$result" != "success" ]]; then
+              echo "One or more jobs failed"
+              exit 1
+            fi
+          done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,19 @@ jobs:
 
       - run: pnpm build
 
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/setup-node@b39b52d1213e96004bfcb1c61a8a6fa8ab84f3e8 # v4.0.1
+
+      - uses: pnpm/action-setup@d882d12c64e032187b2edb46d3a0d003b7a43598 # v2.4.0
+        with:
+          run_install: true
+
+      - run: pnpm test
+
   lint:
     runs-on: ubuntu-latest
 

--- a/package.json
+++ b/package.json
@@ -15,11 +15,14 @@
         "eslint": "^8.56.0",
         "eslint-plugin-simple-import-sort": "^10.0.0",
         "eslint-plugin-unicorn": "^50.0.1",
-        "typescript": "^5.3.3"
+        "tsx": "^4.7.0",
+        "typescript": "^5.3.3",
+        "vitest": "^1.2.0"
     },
     "packageManager": "pnpm@8.8.0",
     "scripts": {
-        "build": "pnpm run --filter './scripts' --filter './ts-perf' build"
+        "build": "pnpm run --filter './scripts' --filter './ts-perf' build",
+        "test": "vitest"
     },
     "pnpm": {
         "requiredScripts": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,9 +32,15 @@ importers:
       eslint-plugin-unicorn:
         specifier: ^50.0.1
         version: 50.0.1(eslint@8.56.0)
+      tsx:
+        specifier: ^4.7.0
+        version: 4.7.0
       typescript:
         specifier: ^5.3.3
         version: 5.3.3
+      vitest:
+        specifier: ^1.2.0
+        version: 1.2.0(@types/node@18.19.5)
 
   scripts:
     devDependencies:
@@ -403,6 +409,213 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/aix-ppc64@0.19.11:
+    resolution: {integrity: sha512-FnzU0LyE3ySQk7UntJO4+qIiQgI7KoODnZg5xzXIrFJlKd2P2gwHsHY4927xj9y5PJmJSzULiUCWmv7iWnNa7g==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [aix]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/android-arm64@0.19.11:
+    resolution: {integrity: sha512-aiu7K/5JnLj//KOnOfEZ0D90obUkRzDMyqd/wNAUQ34m4YUPVhRZpnqKV9uqDGxT7cToSDnIHsGooyIczu9T+Q==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/android-arm@0.19.11:
+    resolution: {integrity: sha512-5OVapq0ClabvKvQ58Bws8+wkLCV+Rxg7tUVbo9xu034Nm536QTII4YzhaFriQ7rMrorfnFKUsArD2lqKbFY4vw==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/android-x64@0.19.11:
+    resolution: {integrity: sha512-eccxjlfGw43WYoY9QgB82SgGgDbibcqyDTlk3l3C0jOVHKxrjdc9CTwDUQd0vkvYg5um0OH+GpxYvp39r+IPOg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/darwin-arm64@0.19.11:
+    resolution: {integrity: sha512-ETp87DRWuSt9KdDVkqSoKoLFHYTrkyz2+65fj9nfXsaV3bMhTCjtQfw3y+um88vGRKRiF7erPrh/ZuIdLUIVxQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/darwin-x64@0.19.11:
+    resolution: {integrity: sha512-fkFUiS6IUK9WYUO/+22omwetaSNl5/A8giXvQlcinLIjVkxwTLSktbF5f/kJMftM2MJp9+fXqZ5ezS7+SALp4g==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/freebsd-arm64@0.19.11:
+    resolution: {integrity: sha512-lhoSp5K6bxKRNdXUtHoNc5HhbXVCS8V0iZmDvyWvYq9S5WSfTIHU2UGjcGt7UeS6iEYp9eeymIl5mJBn0yiuxA==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/freebsd-x64@0.19.11:
+    resolution: {integrity: sha512-JkUqn44AffGXitVI6/AbQdoYAq0TEullFdqcMY/PCUZ36xJ9ZJRtQabzMA+Vi7r78+25ZIBosLTOKnUXBSi1Kw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-arm64@0.19.11:
+    resolution: {integrity: sha512-LneLg3ypEeveBSMuoa0kwMpCGmpu8XQUh+mL8XXwoYZ6Be2qBnVtcDI5azSvh7vioMDhoJFZzp9GWp9IWpYoUg==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-arm@0.19.11:
+    resolution: {integrity: sha512-3CRkr9+vCV2XJbjwgzjPtO8T0SZUmRZla+UL1jw+XqHZPkPgZiyWvbDvl9rqAN8Zl7qJF0O/9ycMtjU67HN9/Q==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-ia32@0.19.11:
+    resolution: {integrity: sha512-caHy++CsD8Bgq2V5CodbJjFPEiDPq8JJmBdeyZ8GWVQMjRD0sU548nNdwPNvKjVpamYYVL40AORekgfIubwHoA==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-loong64@0.19.11:
+    resolution: {integrity: sha512-ppZSSLVpPrwHccvC6nQVZaSHlFsvCQyjnvirnVjbKSHuE5N24Yl8F3UwYUUR1UEPaFObGD2tSvVKbvR+uT1Nrg==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-mips64el@0.19.11:
+    resolution: {integrity: sha512-B5x9j0OgjG+v1dF2DkH34lr+7Gmv0kzX6/V0afF41FkPMMqaQ77pH7CrhWeR22aEeHKaeZVtZ6yFwlxOKPVFyg==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-ppc64@0.19.11:
+    resolution: {integrity: sha512-MHrZYLeCG8vXblMetWyttkdVRjQlQUb/oMgBNurVEnhj4YWOr4G5lmBfZjHYQHHN0g6yDmCAQRR8MUHldvvRDA==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-riscv64@0.19.11:
+    resolution: {integrity: sha512-f3DY++t94uVg141dozDu4CCUkYW+09rWtaWfnb3bqe4w5NqmZd6nPVBm+qbz7WaHZCoqXqHz5p6CM6qv3qnSSQ==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-s390x@0.19.11:
+    resolution: {integrity: sha512-A5xdUoyWJHMMlcSMcPGVLzYzpcY8QP1RtYzX5/bS4dvjBGVxdhuiYyFwp7z74ocV7WDc0n1harxmpq2ePOjI0Q==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-x64@0.19.11:
+    resolution: {integrity: sha512-grbyMlVCvJSfxFQUndw5mCtWs5LO1gUlwP4CDi4iJBbVpZcqLVT29FxgGuBJGSzyOxotFG4LoO5X+M1350zmPA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/netbsd-x64@0.19.11:
+    resolution: {integrity: sha512-13jvrQZJc3P230OhU8xgwUnDeuC/9egsjTkXN49b3GcS5BKvJqZn86aGM8W9pd14Kd+u7HuFBMVtrNGhh6fHEQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/openbsd-x64@0.19.11:
+    resolution: {integrity: sha512-ysyOGZuTp6SNKPE11INDUeFVVQFrhcNDVUgSQVDzqsqX38DjhPEPATpid04LCoUr2WXhQTEZ8ct/EgJCUDpyNw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [openbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/sunos-x64@0.19.11:
+    resolution: {integrity: sha512-Hf+Sad9nVwvtxy4DXCZQqLpgmRTQqyFyhT3bZ4F2XlJCjxGmRFF0Shwn9rzhOYRB61w9VMXUkxlBy56dk9JJiQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/win32-arm64@0.19.11:
+    resolution: {integrity: sha512-0P58Sbi0LctOMOQbpEOvOL44Ne0sqbS0XWHMvvrg6NE5jQ1xguCSSw9jQeUk2lfrXYsKDdOe6K+oZiwKPilYPQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/win32-ia32@0.19.11:
+    resolution: {integrity: sha512-6YOrWS+sDJDmshdBIQU+Uoyh7pQKrdykdefC1avn76ss5c+RN6gut3LZA4E2cH5xUEp5/cA0+YxRaVtRAb0xBg==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/win32-x64@0.19.11:
+    resolution: {integrity: sha512-vfkhltrjCAb603XaFhqhAF4LGDi2M4OrCRrFusyQ+iTLQ/o60QQXxc9cZC/FFpihBI9N1Grn6SMKVJ4KP7Fuiw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esfx/async-deferred@1.0.0:
     resolution: {integrity: sha512-RTJ7PIGwa2EvRlveieefD+N+jNkOh6jBErEExikalC2uOgdLRTleYILbjPKi2a63RActEmokRstNzlKyo3+H2Q==}
     dev: false
@@ -520,6 +733,17 @@ packages:
 
   /@humanwhocodes/object-schema@2.0.1:
     resolution: {integrity: sha512-dvuCeX5fC9dXgJn9t+X5atfmgQAzUOWqS1254Gh0m6i8wKd10ebXkfNKiRK+1GWi/yTvvLDHpoxLr0xxxeslWw==}
+    dev: true
+
+  /@jest/schemas@29.6.3:
+    resolution: {integrity: sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@sinclair/typebox': 0.27.8
+    dev: true
+
+  /@jridgewell/sourcemap-codec@1.4.15:
+    resolution: {integrity: sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==}
     dev: true
 
   /@mapbox/node-pre-gyp@1.0.11:
@@ -668,6 +892,114 @@ packages:
     resolution: {integrity: sha512-AdY5wvN0P2vXBi3b29hxZgSFvdhdxPB9+f0B6s//P9Q8nibRWeA3cHm8UmLpio9ABigkVHJ5NMPk+Mz8VCCyrw==}
     engines: {node: '>=8.0.0'}
     dev: false
+
+  /@rollup/rollup-android-arm-eabi@4.9.5:
+    resolution: {integrity: sha512-idWaG8xeSRCfRq9KpRysDHJ/rEHBEXcHuJ82XY0yYFIWnLMjZv9vF/7DOq8djQ2n3Lk6+3qfSH8AqlmHlmi1MA==}
+    cpu: [arm]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-android-arm64@4.9.5:
+    resolution: {integrity: sha512-f14d7uhAMtsCGjAYwZGv6TwuS3IFaM4ZnGMUn3aCBgkcHAYErhV1Ad97WzBvS2o0aaDv4mVz+syiN0ElMyfBPg==}
+    cpu: [arm64]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-darwin-arm64@4.9.5:
+    resolution: {integrity: sha512-ndoXeLx455FffL68OIUrVr89Xu1WLzAG4n65R8roDlCoYiQcGGg6MALvs2Ap9zs7AHg8mpHtMpwC8jBBjZrT/w==}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-darwin-x64@4.9.5:
+    resolution: {integrity: sha512-UmElV1OY2m/1KEEqTlIjieKfVwRg0Zwg4PLgNf0s3glAHXBN99KLpw5A5lrSYCa1Kp63czTpVll2MAqbZYIHoA==}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-arm-gnueabihf@4.9.5:
+    resolution: {integrity: sha512-Q0LcU61v92tQB6ae+udZvOyZ0wfpGojtAKrrpAaIqmJ7+psq4cMIhT/9lfV6UQIpeItnq/2QDROhNLo00lOD1g==}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-arm64-gnu@4.9.5:
+    resolution: {integrity: sha512-dkRscpM+RrR2Ee3eOQmRWFjmV/payHEOrjyq1VZegRUa5OrZJ2MAxBNs05bZuY0YCtpqETDy1Ix4i/hRqX98cA==}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-arm64-musl@4.9.5:
+    resolution: {integrity: sha512-QaKFVOzzST2xzY4MAmiDmURagWLFh+zZtttuEnuNn19AiZ0T3fhPyjPPGwLNdiDT82ZE91hnfJsUiDwF9DClIQ==}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-riscv64-gnu@4.9.5:
+    resolution: {integrity: sha512-HeGqmRJuyVg6/X6MpE2ur7GbymBPS8Np0S/vQFHDmocfORT+Zt76qu+69NUoxXzGqVP1pzaY6QIi0FJWLC3OPA==}
+    cpu: [riscv64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-x64-gnu@4.9.5:
+    resolution: {integrity: sha512-Dq1bqBdLaZ1Gb/l2e5/+o3B18+8TI9ANlA1SkejZqDgdU/jK/ThYaMPMJpVMMXy2uRHvGKbkz9vheVGdq3cJfA==}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-x64-musl@4.9.5:
+    resolution: {integrity: sha512-ezyFUOwldYpj7AbkwyW9AJ203peub81CaAIVvckdkyH8EvhEIoKzaMFJj0G4qYJ5sw3BpqhFrsCc30t54HV8vg==}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-win32-arm64-msvc@4.9.5:
+    resolution: {integrity: sha512-aHSsMnUw+0UETB0Hlv7B/ZHOGY5bQdwMKJSzGfDfvyhnpmVxLMGnQPGNE9wgqkLUs3+gbG1Qx02S2LLfJ5GaRQ==}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-win32-ia32-msvc@4.9.5:
+    resolution: {integrity: sha512-AiqiLkb9KSf7Lj/o1U3SEP9Zn+5NuVKgFdRIZkvd4N0+bYrTOovVd0+LmYCPQGbocT4kvFyK+LXCDiXPBF3fyA==}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-win32-x64-msvc@4.9.5:
+    resolution: {integrity: sha512-1q+mykKE3Vot1kaFJIDoUFv5TuW+QQVaf2FmTT9krg86pQrGStOSJJ0Zil7CFagyxDuouTepzt5Y5TVzyajOdQ==}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@sinclair/typebox@0.27.8:
+    resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
+    dev: true
 
   /@stdlib/array-float32@0.1.1:
     resolution: {integrity: sha512-6HEwUqo2wyGOeZj2KXwWjoK+O+8NmHAkJIt3dR8gdDbzG51SUsuaUaCCZ4730TAZ/ZM6gSSdja0iwoWOnBAfyQ==}
@@ -1695,6 +2027,10 @@ packages:
     engines: {node: '>= 6'}
     dev: false
 
+  /@types/estree@1.0.5:
+    resolution: {integrity: sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==}
+    dev: true
+
   /@types/json-schema@7.0.15:
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
     dev: true
@@ -1879,6 +2215,45 @@ packages:
     resolution: {integrity: sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==}
     dev: true
 
+  /@vitest/expect@1.2.0:
+    resolution: {integrity: sha512-H+2bHzhyvgp32o7Pgj2h9RTHN0pgYaoi26Oo3mE+dCi1PAqV31kIIVfTbqMO3Bvshd5mIrJLc73EwSRrbol9Lw==}
+    dependencies:
+      '@vitest/spy': 1.2.0
+      '@vitest/utils': 1.2.0
+      chai: 4.4.1
+    dev: true
+
+  /@vitest/runner@1.2.0:
+    resolution: {integrity: sha512-vaJkDoQaNUTroT70OhM0NPznP7H3WyRwt4LvGwCVYs/llLaqhoSLnlIhUClZpbF5RgAee29KRcNz0FEhYcgxqA==}
+    dependencies:
+      '@vitest/utils': 1.2.0
+      p-limit: 5.0.0
+      pathe: 1.1.2
+    dev: true
+
+  /@vitest/snapshot@1.2.0:
+    resolution: {integrity: sha512-P33EE7TrVgB3HDLllrjK/GG6WSnmUtWohbwcQqmm7TAk9AVHpdgf7M3F3qRHKm6vhr7x3eGIln7VH052Smo6Kw==}
+    dependencies:
+      magic-string: 0.30.5
+      pathe: 1.1.2
+      pretty-format: 29.7.0
+    dev: true
+
+  /@vitest/spy@1.2.0:
+    resolution: {integrity: sha512-MNxSAfxUaCeowqyyGwC293yZgk7cECZU9wGb8N1pYQ0yOn/SIr8t0l9XnGRdQZvNV/ZHBYu6GO/W3tj5K3VN1Q==}
+    dependencies:
+      tinyspy: 2.2.0
+    dev: true
+
+  /@vitest/utils@1.2.0:
+    resolution: {integrity: sha512-FyD5bpugsXlwVpTcGLDf3wSPYy8g541fQt14qtzo8mJ4LdEpDKZ9mQy2+qdJm2TZRpjY5JLXihXCgIxiRJgi5g==}
+    dependencies:
+      diff-sequences: 29.6.3
+      estree-walker: 3.0.3
+      loupe: 2.3.7
+      pretty-format: 29.7.0
+    dev: true
+
   /@vscode/test-electron@2.3.8:
     resolution: {integrity: sha512-b4aZZsBKtMGdDljAsOPObnAi7+VWIaYl3ylCz1jTs+oV6BZ4TNHcVNC3xUn0azPeszBmwSBDQYfFESIaUQnrOg==}
     engines: {node: '>=16'}
@@ -1901,6 +2276,11 @@ packages:
       acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
       acorn: 8.11.3
+    dev: true
+
+  /acorn-walk@8.3.2:
+    resolution: {integrity: sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A==}
+    engines: {node: '>=0.4.0'}
     dev: true
 
   /acorn@8.11.3:
@@ -1959,6 +2339,11 @@ packages:
     dependencies:
       color-convert: 2.0.1
 
+  /ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+    dev: true
+
   /aproba@2.0.0:
     resolution: {integrity: sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==}
     dev: false
@@ -1978,6 +2363,10 @@ packages:
   /array-union@2.1.0:
     resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
     engines: {node: '>=8'}
+    dev: true
+
+  /assertion-error@1.1.0:
+    resolution: {integrity: sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==}
     dev: true
 
   /asynckit@0.4.0:
@@ -2037,6 +2426,11 @@ packages:
     engines: {node: '>=6'}
     dev: true
 
+  /cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+    dev: true
+
   /call-bind@1.0.5:
     resolution: {integrity: sha512-C3nQxfFZxFRVoJoGKKI8y3MOEo129NQ+FgQ08iye+Mk4zNZZGdjfs06bVTr+DBSlA66Q2VEcMki/cUCP4SercQ==}
     dependencies:
@@ -2052,6 +2446,19 @@ packages:
 
   /caniuse-lite@1.0.30001576:
     resolution: {integrity: sha512-ff5BdakGe2P3SQsMsiqmt1Lc8221NR1VzHj5jXN5vBny9A6fpze94HiVV/n7XRosOlsShJcvMv5mdnpjOGCEgg==}
+    dev: true
+
+  /chai@4.4.1:
+    resolution: {integrity: sha512-13sOfMv2+DWduEU+/xbun3LScLoqN17nBeTLUsmDfKdoiC1fr0n9PU4guu4AhRcOVFk/sW8LyZWHuhWtQZiF+g==}
+    engines: {node: '>=4'}
+    dependencies:
+      assertion-error: 1.1.0
+      check-error: 1.0.3
+      deep-eql: 4.1.3
+      get-func-name: 2.0.2
+      loupe: 2.3.7
+      pathval: 1.1.1
+      type-detect: 4.0.8
     dev: true
 
   /chalk@1.1.3:
@@ -2084,6 +2491,12 @@ packages:
   /chalk@5.3.0:
     resolution: {integrity: sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+    dev: true
+
+  /check-error@1.0.3:
+    resolution: {integrity: sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==}
+    dependencies:
+      get-func-name: 2.0.2
     dev: true
 
   /chownr@2.0.0:
@@ -2194,6 +2607,13 @@ packages:
     dependencies:
       ms: 2.1.2
 
+  /deep-eql@4.1.3:
+    resolution: {integrity: sha512-WaEtAOpRA1MQ0eohqZjpGD8zdI0Ovsm8mmFhaDN8dvDZzyoUMcYDnf5Y6iu7HTXxf8JDS23qWa4a+hKCDyOPzw==}
+    engines: {node: '>=6'}
+    dependencies:
+      type-detect: 4.0.8
+    dev: true
+
   /deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
     dev: true
@@ -2224,6 +2644,11 @@ packages:
     resolution: {integrity: sha512-UX6sGumvvqSaXgdKGUsgZWqcUyIXZ/vZTrlRT/iobiKhGL0zL4d3osHj3uqllWJK+i+sixDS/3COVEOFbupFyw==}
     engines: {node: '>=8'}
     dev: false
+
+  /diff-sequences@29.6.3:
+    resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dev: true
 
   /dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
@@ -2274,6 +2699,37 @@ packages:
     resolution: {integrity: sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==}
     dependencies:
       is-arrayish: 0.2.1
+    dev: true
+
+  /esbuild@0.19.11:
+    resolution: {integrity: sha512-HJ96Hev2hX/6i5cDVwcqiJBBtuo9+FeIJOtZ9W1kA5M6AMJRHUZlpYZ1/SbEwtO0ioNAW8rUooVpC/WehY2SfA==}
+    engines: {node: '>=12'}
+    hasBin: true
+    requiresBuild: true
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.19.11
+      '@esbuild/android-arm': 0.19.11
+      '@esbuild/android-arm64': 0.19.11
+      '@esbuild/android-x64': 0.19.11
+      '@esbuild/darwin-arm64': 0.19.11
+      '@esbuild/darwin-x64': 0.19.11
+      '@esbuild/freebsd-arm64': 0.19.11
+      '@esbuild/freebsd-x64': 0.19.11
+      '@esbuild/linux-arm': 0.19.11
+      '@esbuild/linux-arm64': 0.19.11
+      '@esbuild/linux-ia32': 0.19.11
+      '@esbuild/linux-loong64': 0.19.11
+      '@esbuild/linux-mips64el': 0.19.11
+      '@esbuild/linux-ppc64': 0.19.11
+      '@esbuild/linux-riscv64': 0.19.11
+      '@esbuild/linux-s390x': 0.19.11
+      '@esbuild/linux-x64': 0.19.11
+      '@esbuild/netbsd-x64': 0.19.11
+      '@esbuild/openbsd-x64': 0.19.11
+      '@esbuild/sunos-x64': 0.19.11
+      '@esbuild/win32-arm64': 0.19.11
+      '@esbuild/win32-ia32': 0.19.11
+      '@esbuild/win32-x64': 0.19.11
     dev: true
 
   /escalade@3.1.1:
@@ -2413,6 +2869,12 @@ packages:
     engines: {node: '>=4.0'}
     dev: true
 
+  /estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+    dependencies:
+      '@types/estree': 1.0.5
+    dev: true
+
   /esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
@@ -2529,6 +2991,14 @@ packages:
   /fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
+  /fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
 
@@ -2552,6 +3022,10 @@ packages:
     engines: {node: '>=18'}
     dev: true
 
+  /get-func-name@2.0.2:
+    resolution: {integrity: sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==}
+    dev: true
+
   /get-intrinsic@1.2.2:
     resolution: {integrity: sha512-0gSo4ml/0j98Y3lngkFEot/zhiCeWsbYIlZ+uZOVgzLyLaUw7wxUL+nCTP0XJvJg1AXulJRI3UJi8GsbDuxdGA==}
     dependencies:
@@ -2564,6 +3038,12 @@ packages:
   /get-stream@8.0.1:
     resolution: {integrity: sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==}
     engines: {node: '>=16'}
+    dev: true
+
+  /get-tsconfig@4.7.2:
+    resolution: {integrity: sha512-wuMsz4leaj5hbGgg4IvDU0bqJagpftG5l5cXIAvo8uZrqn0NJqwtfupTN00VnkQJPcIRrxYrm1Ue24btpCha2A==}
+    dependencies:
+      resolve-pkg-maps: 1.0.0
     dev: true
 
   /glob-parent@5.1.2:
@@ -2862,6 +3342,10 @@ packages:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
     dev: true
 
+  /jsonc-parser@3.2.0:
+    resolution: {integrity: sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==}
+    dev: true
+
   /jszip@3.10.1:
     resolution: {integrity: sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==}
     dependencies:
@@ -2895,6 +3379,14 @@ packages:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
     dev: true
 
+  /local-pkg@0.5.0:
+    resolution: {integrity: sha512-ok6z3qlYyCDS4ZEU27HaU6x/xZa9Whf8jD4ptH5UZTQYZVYeb9bnZ3ojVhiJNLiXK1Hfc0GNbLXcmZ5plLDDBg==}
+    engines: {node: '>=14'}
+    dependencies:
+      mlly: 1.5.0
+      pkg-types: 1.0.3
+    dev: true
+
   /locate-path@5.0.0:
     resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
     engines: {node: '>=8'}
@@ -2921,11 +3413,24 @@ packages:
       is-unicode-supported: 1.3.0
     dev: true
 
+  /loupe@2.3.7:
+    resolution: {integrity: sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==}
+    dependencies:
+      get-func-name: 2.0.2
+    dev: true
+
   /lru-cache@6.0.0:
     resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
     engines: {node: '>=10'}
     dependencies:
       yallist: 4.0.0
+
+  /magic-string@0.30.5:
+    resolution: {integrity: sha512-7xlpfBaQaP/T6Vh8MO/EqXSW5En6INHEvEXQiuff7Gku0PWjU3uf6w/j9o7O+SpB5fOAkrI5HeoNgwjEO0pFsA==}
+    engines: {node: '>=12'}
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.4.15
+    dev: true
 
   /make-dir@3.1.0:
     resolution: {integrity: sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==}
@@ -3020,12 +3525,27 @@ packages:
     hasBin: true
     dev: false
 
+  /mlly@1.5.0:
+    resolution: {integrity: sha512-NPVQvAY1xr1QoVeG0cy8yUYC7FQcOx6evl/RjT1wL5FvzPnzOysoqB/jmx/DhssT2dYa8nxECLAaFI/+gVLhDQ==}
+    dependencies:
+      acorn: 8.11.3
+      pathe: 1.1.2
+      pkg-types: 1.0.3
+      ufo: 1.3.2
+    dev: true
+
   /ms@2.0.0:
     resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
     dev: false
 
   /ms@2.1.2:
     resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
+
+  /nanoid@3.3.7:
+    resolution: {integrity: sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+    dev: true
 
   /natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
@@ -3149,6 +3669,13 @@ packages:
       yocto-queue: 0.1.0
     dev: true
 
+  /p-limit@5.0.0:
+    resolution: {integrity: sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==}
+    engines: {node: '>=18'}
+    dependencies:
+      yocto-queue: 1.0.0
+    dev: true
+
   /p-locate@4.1.0:
     resolution: {integrity: sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==}
     engines: {node: '>=8'}
@@ -3216,6 +3743,14 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
+  /pathe@1.1.2:
+    resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
+    dev: true
+
+  /pathval@1.1.1:
+    resolution: {integrity: sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==}
+    dev: true
+
   /picocolors@1.0.0:
     resolution: {integrity: sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==}
     dev: true
@@ -3225,9 +3760,26 @@ packages:
     engines: {node: '>=8.6'}
     dev: true
 
+  /pkg-types@1.0.3:
+    resolution: {integrity: sha512-nN7pYi0AQqJnoLPC9eHFQ8AcyaixBUOwvqc5TDnIKCMEE6I0y8P7OKA7fPexsXGCGxQDl/cmrLAp26LhcwxZ4A==}
+    dependencies:
+      jsonc-parser: 3.2.0
+      mlly: 1.5.0
+      pathe: 1.1.2
+    dev: true
+
   /pluralize@8.0.0:
     resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
     engines: {node: '>=4'}
+    dev: true
+
+  /postcss@8.4.33:
+    resolution: {integrity: sha512-Kkpbhhdjw2qQs2O2DGX+8m5OVqEcbB9HRBvuYM9pgrjEFUg30A9LmXNlTAUj4S9kgtGyrMbTzVjH7E+s5Re2yg==}
+    engines: {node: ^10 || ^12 || >=14}
+    dependencies:
+      nanoid: 3.3.7
+      picocolors: 1.0.0
+      source-map-js: 1.0.2
     dev: true
 
   /power-options@0.3.4:
@@ -3244,6 +3796,15 @@ packages:
   /prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
+    dev: true
+
+  /pretty-format@29.7.0:
+    resolution: {integrity: sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@jest/schemas': 29.6.3
+      ansi-styles: 5.2.0
+      react-is: 18.2.0
     dev: true
 
   /process-nextick-args@2.0.1:
@@ -3269,6 +3830,10 @@ packages:
 
   /queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+    dev: true
+
+  /react-is@18.2.0:
+    resolution: {integrity: sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==}
     dev: true
 
   /read-pkg-up@7.0.1:
@@ -3328,6 +3893,10 @@ packages:
     engines: {node: '>=4'}
     dev: true
 
+  /resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+    dev: true
+
   /resolve@1.22.8:
     resolution: {integrity: sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==}
     hasBin: true
@@ -3354,6 +3923,29 @@ packages:
     hasBin: true
     dependencies:
       glob: 7.2.3
+
+  /rollup@4.9.5:
+    resolution: {integrity: sha512-E4vQW0H/mbNMw2yLSqJyjtkHY9dslf/p0zuT1xehNRqUTBOFMqEjguDvqhXr7N7r/4ttb2jr4T41d3dncmIgbQ==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+    dependencies:
+      '@types/estree': 1.0.5
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.9.5
+      '@rollup/rollup-android-arm64': 4.9.5
+      '@rollup/rollup-darwin-arm64': 4.9.5
+      '@rollup/rollup-darwin-x64': 4.9.5
+      '@rollup/rollup-linux-arm-gnueabihf': 4.9.5
+      '@rollup/rollup-linux-arm64-gnu': 4.9.5
+      '@rollup/rollup-linux-arm64-musl': 4.9.5
+      '@rollup/rollup-linux-riscv64-gnu': 4.9.5
+      '@rollup/rollup-linux-x64-gnu': 4.9.5
+      '@rollup/rollup-linux-x64-musl': 4.9.5
+      '@rollup/rollup-win32-arm64-msvc': 4.9.5
+      '@rollup/rollup-win32-ia32-msvc': 4.9.5
+      '@rollup/rollup-win32-x64-msvc': 4.9.5
+      fsevents: 2.3.3
+    dev: true
 
   /run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
@@ -3428,6 +4020,10 @@ packages:
       object-inspect: 1.13.1
     dev: true
 
+  /siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+    dev: true
+
   /signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
@@ -3439,6 +4035,11 @@ packages:
   /slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
+    dev: true
+
+  /source-map-js@1.0.2:
+    resolution: {integrity: sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==}
+    engines: {node: '>=0.10.0'}
     dev: true
 
   /source-map-support@0.5.21:
@@ -3472,6 +4073,14 @@ packages:
 
   /spdx-license-ids@3.0.16:
     resolution: {integrity: sha512-eWN+LnM3GR6gPu35WxNgbGl8rmY1AEmoMDvL/QD6zYmPWgywxWqJWNdLGT+ke8dKNWrcYgYjPpG5gbTfghP8rw==}
+    dev: true
+
+  /stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+    dev: true
+
+  /std-env@3.7.0:
+    resolution: {integrity: sha512-JPbdCEQLj1w5GilpiHAx3qJvFndqybBysA3qUOnznweH4QbNYUsW/ea8QzSrnh0vNsezMMw5bcVool8lM0gwzg==}
     dev: true
 
   /stdin-discarder@0.2.2:
@@ -3546,6 +4155,12 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
+  /strip-literal@1.3.0:
+    resolution: {integrity: sha512-PugKzOsyXpArk0yWmUwqOZecSO0GH0bPoctLcqNDH9J04pVW3lflYE0ujElBGTloevcxF5MofAOZ7C5l2b+wLg==}
+    dependencies:
+      acorn: 8.11.3
+    dev: true
+
   /supports-color@2.0.0:
     resolution: {integrity: sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g==}
     engines: {node: '>=0.8.0'}
@@ -3592,6 +4207,20 @@ packages:
     resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
     dev: true
 
+  /tinybench@2.5.1:
+    resolution: {integrity: sha512-65NKvSuAVDP/n4CqH+a9w2kTlLReS9vhsAP06MWx+/89nMinJyB2icyl58RIcqCmIggpojIGeuJGhjU1aGMBSg==}
+    dev: true
+
+  /tinypool@0.8.1:
+    resolution: {integrity: sha512-zBTCK0cCgRROxvs9c0CGK838sPkeokNGdQVUUwHAbynHFlmyJYj825f/oRs528HaIJ97lo0pLIlDUzwN+IorWg==}
+    engines: {node: '>=14.0.0'}
+    dev: true
+
+  /tinyspy@2.2.0:
+    resolution: {integrity: sha512-d2eda04AN/cPOR89F7Xv5bK/jrQEhmcLFe6HFldoeO9AJtps+fqEnh486vnT/8y4bw38pSyxDcTCAq+Ks2aJTg==}
+    engines: {node: '>=14.0.0'}
+    dev: true
+
   /tmp@0.2.1:
     resolution: {integrity: sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==}
     engines: {node: '>=8.17.0'}
@@ -3627,6 +4256,17 @@ packages:
     resolution: {integrity: sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==}
     dev: false
 
+  /tsx@4.7.0:
+    resolution: {integrity: sha512-I+t79RYPlEYlHn9a+KzwrvEwhJg35h/1zHsLC2JXvhC2mdynMv6Zxzvhv5EMV6VF5qJlLlkSnMVvdZV3PSIGcg==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+    dependencies:
+      esbuild: 0.19.11
+      get-tsconfig: 4.7.2
+    optionalDependencies:
+      fsevents: 2.3.3
+    dev: true
+
   /tunnel@0.0.6:
     resolution: {integrity: sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==}
     engines: {node: '>=0.6.11 <=0.7.0 || >=0.7.3'}
@@ -3636,6 +4276,11 @@ packages:
     engines: {node: '>= 0.8.0'}
     dependencies:
       prelude-ls: 1.2.1
+    dev: true
+
+  /type-detect@4.0.8:
+    resolution: {integrity: sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==}
+    engines: {node: '>=4'}
     dev: true
 
   /type-fest@0.20.2:
@@ -3665,6 +4310,10 @@ packages:
     resolution: {integrity: sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==}
     engines: {node: '>=14.17'}
     hasBin: true
+    dev: true
+
+  /ufo@1.3.2:
+    resolution: {integrity: sha512-o+ORpgGwaYQXgqGDwd+hkS4PuZ3QnmqMMxRuajK/a38L6fTpcE5GPIfrf+L/KemFzfUpeUQc1rRS1iDBozvnFA==}
     dev: true
 
   /underscore@1.13.6:
@@ -3711,6 +4360,120 @@ packages:
       spdx-expression-parse: 3.0.1
     dev: true
 
+  /vite-node@1.2.0(@types/node@18.19.5):
+    resolution: {integrity: sha512-ETnQTHeAbbOxl7/pyBck9oAPZZZo+kYnFt1uQDD+hPReOc+wCjXw4r4jHriBRuVDB5isHmPXxrfc1yJnfBERqg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    dependencies:
+      cac: 6.7.14
+      debug: 4.3.4
+      pathe: 1.1.2
+      picocolors: 1.0.0
+      vite: 5.0.11(@types/node@18.19.5)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+    dev: true
+
+  /vite@5.0.11(@types/node@18.19.5):
+    resolution: {integrity: sha512-XBMnDjZcNAw/G1gEiskiM1v6yzM4GE5aMGvhWTlHAYYhxb7S3/V1s3m2LDHa8Vh6yIWYYB0iJwsEaS523c4oYA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.19.5
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+    dependencies:
+      '@types/node': 18.19.5
+      esbuild: 0.19.11
+      postcss: 8.4.33
+      rollup: 4.9.5
+    optionalDependencies:
+      fsevents: 2.3.3
+    dev: true
+
+  /vitest@1.2.0(@types/node@18.19.5):
+    resolution: {integrity: sha512-Ixs5m7BjqvLHXcibkzKRQUvD/XLw0E3rvqaCMlrm/0LMsA0309ZqYvTlPzkhh81VlEyVZXFlwWnkhb6/UMtcaQ==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/node': ^18.19.5
+      '@vitest/browser': ^1.0.0
+      '@vitest/ui': ^1.0.0
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+    dependencies:
+      '@types/node': 18.19.5
+      '@vitest/expect': 1.2.0
+      '@vitest/runner': 1.2.0
+      '@vitest/snapshot': 1.2.0
+      '@vitest/spy': 1.2.0
+      '@vitest/utils': 1.2.0
+      acorn-walk: 8.3.2
+      cac: 6.7.14
+      chai: 4.4.1
+      debug: 4.3.4
+      execa: 8.0.1
+      local-pkg: 0.5.0
+      magic-string: 0.30.5
+      pathe: 1.1.2
+      picocolors: 1.0.0
+      std-env: 3.7.0
+      strip-literal: 1.3.0
+      tinybench: 2.5.1
+      tinypool: 0.8.1
+      vite: 5.0.11(@types/node@18.19.5)
+      vite-node: 1.2.0(@types/node@18.19.5)
+      why-is-node-running: 2.2.2
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - sass
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+    dev: true
+
   /webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
     dev: false
@@ -3728,6 +4491,15 @@ packages:
     hasBin: true
     dependencies:
       isexe: 2.0.0
+    dev: true
+
+  /why-is-node-running@2.2.2:
+    resolution: {integrity: sha512-6tSwToZxTOcotxHeA+qGCq1mVzKR3CwcJGmVcY+QE8SHy6TnpFnh8PAvPNHYr7EcuVeG0QSMxtYCuO1ta/G/oA==}
+    engines: {node: '>=8'}
+    hasBin: true
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
     dev: true
 
   /wide-align@1.1.5:
@@ -3758,4 +4530,9 @@ packages:
   /yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+    dev: true
+
+  /yocto-queue@1.0.0:
+    resolution: {integrity: sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==}
+    engines: {node: '>=12.20'}
     dev: true

--- a/scripts/src/__tests__/__snapshots__/generateMatrix.test.ts.snap
+++ b/scripts/src/__tests__/__snapshots__/generateMatrix.test.ts.snap
@@ -1,0 +1,960 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`generateMatrix { preset: 'bun', env: {} } 1`] = `
+"setting output MATRIX_any={"tsc_bun_1_0_15_Angular":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_bun_1_0_15_Angular","TSPERF_JOB_HOST":"bun@1.0.15","TSPERF_JOB_SCENARIO":"Angular","TSPERF_JOB_ITERATIONS":12,"TSPERF_JOB_LOCATION":"internal"},"tsc_bun_1_0_15_Monaco":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_bun_1_0_15_Monaco","TSPERF_JOB_HOST":"bun@1.0.15","TSPERF_JOB_SCENARIO":"Monaco","TSPERF_JOB_ITERATIONS":12,"TSPERF_JOB_LOCATION":"internal"},"tsc_bun_1_0_15_TFS":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_bun_1_0_15_TFS","TSPERF_JOB_HOST":"bun@1.0.15","TSPERF_JOB_SCENARIO":"TFS","TSPERF_JOB_ITERATIONS":12,"TSPERF_JOB_LOCATION":"internal"},"tsc_bun_1_0_15_material_ui":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_bun_1_0_15_material_ui","TSPERF_JOB_HOST":"bun@1.0.15","TSPERF_JOB_SCENARIO":"material-ui","TSPERF_JOB_ITERATIONS":12,"TSPERF_JOB_LOCATION":"internal"},"tsc_bun_1_0_15_Compiler_Unions":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_bun_1_0_15_Compiler_Unions","TSPERF_JOB_HOST":"bun@1.0.15","TSPERF_JOB_SCENARIO":"Compiler-Unions","TSPERF_JOB_ITERATIONS":12,"TSPERF_JOB_LOCATION":"internal"},"tsc_bun_1_0_15_xstate":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_bun_1_0_15_xstate","TSPERF_JOB_HOST":"bun@1.0.15","TSPERF_JOB_SCENARIO":"xstate","TSPERF_JOB_ITERATIONS":12,"TSPERF_JOB_LOCATION":"internal"},"startup_bun_1_0_15_tsc_startup":{"TSPERF_JOB_KIND":"startup","TSPERF_JOB_NAME":"startup_bun_1_0_15_tsc_startup","TSPERF_JOB_HOST":"bun@1.0.15","TSPERF_JOB_SCENARIO":"tsc-startup","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"startup_bun_1_0_15_tsserverlibrary_startup":{"TSPERF_JOB_KIND":"startup","TSPERF_JOB_NAME":"startup_bun_1_0_15_tsserverlibrary_startup","TSPERF_JOB_HOST":"bun@1.0.15","TSPERF_JOB_SCENARIO":"tsserverlibrary-startup","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"startup_bun_1_0_15_typescript_startup":{"TSPERF_JOB_KIND":"startup","TSPERF_JOB_NAME":"startup_bun_1_0_15_typescript_startup","TSPERF_JOB_HOST":"bun@1.0.15","TSPERF_JOB_SCENARIO":"typescript-startup","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"}}
+##vso[task.setvariable variable=MATRIX_any;isOutput=true]{"tsc_bun_1_0_15_Angular":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_bun_1_0_15_Angular","TSPERF_JOB_HOST":"bun@1.0.15","TSPERF_JOB_SCENARIO":"Angular","TSPERF_JOB_ITERATIONS":12,"TSPERF_JOB_LOCATION":"internal"},"tsc_bun_1_0_15_Monaco":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_bun_1_0_15_Monaco","TSPERF_JOB_HOST":"bun@1.0.15","TSPERF_JOB_SCENARIO":"Monaco","TSPERF_JOB_ITERATIONS":12,"TSPERF_JOB_LOCATION":"internal"},"tsc_bun_1_0_15_TFS":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_bun_1_0_15_TFS","TSPERF_JOB_HOST":"bun@1.0.15","TSPERF_JOB_SCENARIO":"TFS","TSPERF_JOB_ITERATIONS":12,"TSPERF_JOB_LOCATION":"internal"},"tsc_bun_1_0_15_material_ui":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_bun_1_0_15_material_ui","TSPERF_JOB_HOST":"bun@1.0.15","TSPERF_JOB_SCENARIO":"material-ui","TSPERF_JOB_ITERATIONS":12,"TSPERF_JOB_LOCATION":"internal"},"tsc_bun_1_0_15_Compiler_Unions":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_bun_1_0_15_Compiler_Unions","TSPERF_JOB_HOST":"bun@1.0.15","TSPERF_JOB_SCENARIO":"Compiler-Unions","TSPERF_JOB_ITERATIONS":12,"TSPERF_JOB_LOCATION":"internal"},"tsc_bun_1_0_15_xstate":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_bun_1_0_15_xstate","TSPERF_JOB_HOST":"bun@1.0.15","TSPERF_JOB_SCENARIO":"xstate","TSPERF_JOB_ITERATIONS":12,"TSPERF_JOB_LOCATION":"internal"},"startup_bun_1_0_15_tsc_startup":{"TSPERF_JOB_KIND":"startup","TSPERF_JOB_NAME":"startup_bun_1_0_15_tsc_startup","TSPERF_JOB_HOST":"bun@1.0.15","TSPERF_JOB_SCENARIO":"tsc-startup","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"startup_bun_1_0_15_tsserverlibrary_startup":{"TSPERF_JOB_KIND":"startup","TSPERF_JOB_NAME":"startup_bun_1_0_15_tsserverlibrary_startup","TSPERF_JOB_HOST":"bun@1.0.15","TSPERF_JOB_SCENARIO":"tsserverlibrary-startup","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"startup_bun_1_0_15_typescript_startup":{"TSPERF_JOB_KIND":"startup","TSPERF_JOB_NAME":"startup_bun_1_0_15_typescript_startup","TSPERF_JOB_HOST":"bun@1.0.15","TSPERF_JOB_SCENARIO":"typescript-startup","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"}}
+{
+    "tsc_bun_1_0_15_Angular": {
+        "TSPERF_JOB_KIND": "tsc",
+        "TSPERF_JOB_NAME": "tsc_bun_1_0_15_Angular",
+        "TSPERF_JOB_HOST": "bun@1.0.15",
+        "TSPERF_JOB_SCENARIO": "Angular",
+        "TSPERF_JOB_ITERATIONS": 12,
+        "TSPERF_JOB_LOCATION": "internal"
+    },
+    "tsc_bun_1_0_15_Monaco": {
+        "TSPERF_JOB_KIND": "tsc",
+        "TSPERF_JOB_NAME": "tsc_bun_1_0_15_Monaco",
+        "TSPERF_JOB_HOST": "bun@1.0.15",
+        "TSPERF_JOB_SCENARIO": "Monaco",
+        "TSPERF_JOB_ITERATIONS": 12,
+        "TSPERF_JOB_LOCATION": "internal"
+    },
+    "tsc_bun_1_0_15_TFS": {
+        "TSPERF_JOB_KIND": "tsc",
+        "TSPERF_JOB_NAME": "tsc_bun_1_0_15_TFS",
+        "TSPERF_JOB_HOST": "bun@1.0.15",
+        "TSPERF_JOB_SCENARIO": "TFS",
+        "TSPERF_JOB_ITERATIONS": 12,
+        "TSPERF_JOB_LOCATION": "internal"
+    },
+    "tsc_bun_1_0_15_material_ui": {
+        "TSPERF_JOB_KIND": "tsc",
+        "TSPERF_JOB_NAME": "tsc_bun_1_0_15_material_ui",
+        "TSPERF_JOB_HOST": "bun@1.0.15",
+        "TSPERF_JOB_SCENARIO": "material-ui",
+        "TSPERF_JOB_ITERATIONS": 12,
+        "TSPERF_JOB_LOCATION": "internal"
+    },
+    "tsc_bun_1_0_15_Compiler_Unions": {
+        "TSPERF_JOB_KIND": "tsc",
+        "TSPERF_JOB_NAME": "tsc_bun_1_0_15_Compiler_Unions",
+        "TSPERF_JOB_HOST": "bun@1.0.15",
+        "TSPERF_JOB_SCENARIO": "Compiler-Unions",
+        "TSPERF_JOB_ITERATIONS": 12,
+        "TSPERF_JOB_LOCATION": "internal"
+    },
+    "tsc_bun_1_0_15_xstate": {
+        "TSPERF_JOB_KIND": "tsc",
+        "TSPERF_JOB_NAME": "tsc_bun_1_0_15_xstate",
+        "TSPERF_JOB_HOST": "bun@1.0.15",
+        "TSPERF_JOB_SCENARIO": "xstate",
+        "TSPERF_JOB_ITERATIONS": 12,
+        "TSPERF_JOB_LOCATION": "internal"
+    },
+    "startup_bun_1_0_15_tsc_startup": {
+        "TSPERF_JOB_KIND": "startup",
+        "TSPERF_JOB_NAME": "startup_bun_1_0_15_tsc_startup",
+        "TSPERF_JOB_HOST": "bun@1.0.15",
+        "TSPERF_JOB_SCENARIO": "tsc-startup",
+        "TSPERF_JOB_ITERATIONS": 6,
+        "TSPERF_JOB_LOCATION": "internal"
+    },
+    "startup_bun_1_0_15_tsserverlibrary_startup": {
+        "TSPERF_JOB_KIND": "startup",
+        "TSPERF_JOB_NAME": "startup_bun_1_0_15_tsserverlibrary_startup",
+        "TSPERF_JOB_HOST": "bun@1.0.15",
+        "TSPERF_JOB_SCENARIO": "tsserverlibrary-startup",
+        "TSPERF_JOB_ITERATIONS": 6,
+        "TSPERF_JOB_LOCATION": "internal"
+    },
+    "startup_bun_1_0_15_typescript_startup": {
+        "TSPERF_JOB_KIND": "startup",
+        "TSPERF_JOB_NAME": "startup_bun_1_0_15_typescript_startup",
+        "TSPERF_JOB_HOST": "bun@1.0.15",
+        "TSPERF_JOB_SCENARIO": "typescript-startup",
+        "TSPERF_JOB_ITERATIONS": 6,
+        "TSPERF_JOB_LOCATION": "internal"
+    }
+}
+setting output MATRIX_ts_perf1={}
+##vso[task.setvariable variable=MATRIX_ts_perf1;isOutput=true]{}
+{}
+setting output MATRIX_ts_perf2={}
+##vso[task.setvariable variable=MATRIX_ts_perf2;isOutput=true]{}
+{}
+setting output MATRIX_ts_perf3={}
+##vso[task.setvariable variable=MATRIX_ts_perf3;isOutput=true]{}
+{}
+setting output MATRIX_ts_perf4={}
+##vso[task.setvariable variable=MATRIX_ts_perf4;isOutput=true]{}
+{}
+setting output TSPERF_PROCESS_KINDS=tsc startup
+##vso[task.setvariable variable=TSPERF_PROCESS_KINDS;isOutput=true]tsc startup
+setting output TSPERF_PROCESS_LOCATIONS=internal
+##vso[task.setvariable variable=TSPERF_PROCESS_LOCATIONS;isOutput=true]internal"
+`;
+
+exports[`generateMatrix { preset: 'bun', env: {} } 2`] = `""`;
+
+exports[`generateMatrix { preset: 'bun', env: {} } 3`] = `0`;
+
+exports[`generateMatrix { preset: 'full', env: { USE_BASELINE_MACHINE: 'true' } } 1`] = `
+"setting output MATRIX_any={}
+##vso[task.setvariable variable=MATRIX_any;isOutput=true]{}
+{}
+setting output MATRIX_ts_perf1={"tsc_node_20_5_1_Angular":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_node_20_5_1_Angular","TSPERF_JOB_HOST":"node@20.5.1","TSPERF_JOB_SCENARIO":"Angular","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"tsc_node_20_5_1_material_ui":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_node_20_5_1_material_ui","TSPERF_JOB_HOST":"node@20.5.1","TSPERF_JOB_SCENARIO":"material-ui","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"tsc_node_18_15_0_Angular":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_node_18_15_0_Angular","TSPERF_JOB_HOST":"node@18.15.0","TSPERF_JOB_SCENARIO":"Angular","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"tsc_node_18_15_0_material_ui":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_node_18_15_0_material_ui","TSPERF_JOB_HOST":"node@18.15.0","TSPERF_JOB_SCENARIO":"material-ui","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"tsc_node_16_17_1_Angular":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_node_16_17_1_Angular","TSPERF_JOB_HOST":"node@16.17.1","TSPERF_JOB_SCENARIO":"Angular","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"tsc_node_16_17_1_material_ui":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_node_16_17_1_material_ui","TSPERF_JOB_HOST":"node@16.17.1","TSPERF_JOB_SCENARIO":"material-ui","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"tsserver_node_16_17_1_Compiler_UnionsTSServer":{"TSPERF_JOB_KIND":"tsserver","TSPERF_JOB_NAME":"tsserver_node_16_17_1_Compiler_UnionsTSServer","TSPERF_JOB_HOST":"node@16.17.1","TSPERF_JOB_SCENARIO":"Compiler-UnionsTSServer","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"startup_node_16_17_1_tsc_startup":{"TSPERF_JOB_KIND":"startup","TSPERF_JOB_NAME":"startup_node_16_17_1_tsc_startup","TSPERF_JOB_HOST":"node@16.17.1","TSPERF_JOB_SCENARIO":"tsc-startup","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"startup_node_16_17_1_typescript_startup":{"TSPERF_JOB_KIND":"startup","TSPERF_JOB_NAME":"startup_node_16_17_1_typescript_startup","TSPERF_JOB_HOST":"node@16.17.1","TSPERF_JOB_SCENARIO":"typescript-startup","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"}}
+##vso[task.setvariable variable=MATRIX_ts_perf1;isOutput=true]{"tsc_node_20_5_1_Angular":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_node_20_5_1_Angular","TSPERF_JOB_HOST":"node@20.5.1","TSPERF_JOB_SCENARIO":"Angular","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"tsc_node_20_5_1_material_ui":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_node_20_5_1_material_ui","TSPERF_JOB_HOST":"node@20.5.1","TSPERF_JOB_SCENARIO":"material-ui","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"tsc_node_18_15_0_Angular":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_node_18_15_0_Angular","TSPERF_JOB_HOST":"node@18.15.0","TSPERF_JOB_SCENARIO":"Angular","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"tsc_node_18_15_0_material_ui":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_node_18_15_0_material_ui","TSPERF_JOB_HOST":"node@18.15.0","TSPERF_JOB_SCENARIO":"material-ui","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"tsc_node_16_17_1_Angular":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_node_16_17_1_Angular","TSPERF_JOB_HOST":"node@16.17.1","TSPERF_JOB_SCENARIO":"Angular","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"tsc_node_16_17_1_material_ui":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_node_16_17_1_material_ui","TSPERF_JOB_HOST":"node@16.17.1","TSPERF_JOB_SCENARIO":"material-ui","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"tsserver_node_16_17_1_Compiler_UnionsTSServer":{"TSPERF_JOB_KIND":"tsserver","TSPERF_JOB_NAME":"tsserver_node_16_17_1_Compiler_UnionsTSServer","TSPERF_JOB_HOST":"node@16.17.1","TSPERF_JOB_SCENARIO":"Compiler-UnionsTSServer","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"startup_node_16_17_1_tsc_startup":{"TSPERF_JOB_KIND":"startup","TSPERF_JOB_NAME":"startup_node_16_17_1_tsc_startup","TSPERF_JOB_HOST":"node@16.17.1","TSPERF_JOB_SCENARIO":"tsc-startup","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"startup_node_16_17_1_typescript_startup":{"TSPERF_JOB_KIND":"startup","TSPERF_JOB_NAME":"startup_node_16_17_1_typescript_startup","TSPERF_JOB_HOST":"node@16.17.1","TSPERF_JOB_SCENARIO":"typescript-startup","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"}}
+{
+    "tsc_node_20_5_1_Angular": {
+        "TSPERF_JOB_KIND": "tsc",
+        "TSPERF_JOB_NAME": "tsc_node_20_5_1_Angular",
+        "TSPERF_JOB_HOST": "node@20.5.1",
+        "TSPERF_JOB_SCENARIO": "Angular",
+        "TSPERF_JOB_ITERATIONS": 6,
+        "TSPERF_JOB_LOCATION": "internal"
+    },
+    "tsc_node_20_5_1_material_ui": {
+        "TSPERF_JOB_KIND": "tsc",
+        "TSPERF_JOB_NAME": "tsc_node_20_5_1_material_ui",
+        "TSPERF_JOB_HOST": "node@20.5.1",
+        "TSPERF_JOB_SCENARIO": "material-ui",
+        "TSPERF_JOB_ITERATIONS": 6,
+        "TSPERF_JOB_LOCATION": "internal"
+    },
+    "tsc_node_18_15_0_Angular": {
+        "TSPERF_JOB_KIND": "tsc",
+        "TSPERF_JOB_NAME": "tsc_node_18_15_0_Angular",
+        "TSPERF_JOB_HOST": "node@18.15.0",
+        "TSPERF_JOB_SCENARIO": "Angular",
+        "TSPERF_JOB_ITERATIONS": 6,
+        "TSPERF_JOB_LOCATION": "internal"
+    },
+    "tsc_node_18_15_0_material_ui": {
+        "TSPERF_JOB_KIND": "tsc",
+        "TSPERF_JOB_NAME": "tsc_node_18_15_0_material_ui",
+        "TSPERF_JOB_HOST": "node@18.15.0",
+        "TSPERF_JOB_SCENARIO": "material-ui",
+        "TSPERF_JOB_ITERATIONS": 6,
+        "TSPERF_JOB_LOCATION": "internal"
+    },
+    "tsc_node_16_17_1_Angular": {
+        "TSPERF_JOB_KIND": "tsc",
+        "TSPERF_JOB_NAME": "tsc_node_16_17_1_Angular",
+        "TSPERF_JOB_HOST": "node@16.17.1",
+        "TSPERF_JOB_SCENARIO": "Angular",
+        "TSPERF_JOB_ITERATIONS": 6,
+        "TSPERF_JOB_LOCATION": "internal"
+    },
+    "tsc_node_16_17_1_material_ui": {
+        "TSPERF_JOB_KIND": "tsc",
+        "TSPERF_JOB_NAME": "tsc_node_16_17_1_material_ui",
+        "TSPERF_JOB_HOST": "node@16.17.1",
+        "TSPERF_JOB_SCENARIO": "material-ui",
+        "TSPERF_JOB_ITERATIONS": 6,
+        "TSPERF_JOB_LOCATION": "internal"
+    },
+    "tsserver_node_16_17_1_Compiler_UnionsTSServer": {
+        "TSPERF_JOB_KIND": "tsserver",
+        "TSPERF_JOB_NAME": "tsserver_node_16_17_1_Compiler_UnionsTSServer",
+        "TSPERF_JOB_HOST": "node@16.17.1",
+        "TSPERF_JOB_SCENARIO": "Compiler-UnionsTSServer",
+        "TSPERF_JOB_ITERATIONS": 6,
+        "TSPERF_JOB_LOCATION": "internal"
+    },
+    "startup_node_16_17_1_tsc_startup": {
+        "TSPERF_JOB_KIND": "startup",
+        "TSPERF_JOB_NAME": "startup_node_16_17_1_tsc_startup",
+        "TSPERF_JOB_HOST": "node@16.17.1",
+        "TSPERF_JOB_SCENARIO": "tsc-startup",
+        "TSPERF_JOB_ITERATIONS": 6,
+        "TSPERF_JOB_LOCATION": "internal"
+    },
+    "startup_node_16_17_1_typescript_startup": {
+        "TSPERF_JOB_KIND": "startup",
+        "TSPERF_JOB_NAME": "startup_node_16_17_1_typescript_startup",
+        "TSPERF_JOB_HOST": "node@16.17.1",
+        "TSPERF_JOB_SCENARIO": "typescript-startup",
+        "TSPERF_JOB_ITERATIONS": 6,
+        "TSPERF_JOB_LOCATION": "internal"
+    }
+}
+setting output MATRIX_ts_perf2={"tsc_node_20_5_1_Monaco":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_node_20_5_1_Monaco","TSPERF_JOB_HOST":"node@20.5.1","TSPERF_JOB_SCENARIO":"Monaco","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"tsc_node_20_5_1_Compiler_Unions":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_node_20_5_1_Compiler_Unions","TSPERF_JOB_HOST":"node@20.5.1","TSPERF_JOB_SCENARIO":"Compiler-Unions","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"tsc_node_18_15_0_Monaco":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_node_18_15_0_Monaco","TSPERF_JOB_HOST":"node@18.15.0","TSPERF_JOB_SCENARIO":"Monaco","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"tsc_node_18_15_0_Compiler_Unions":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_node_18_15_0_Compiler_Unions","TSPERF_JOB_HOST":"node@18.15.0","TSPERF_JOB_SCENARIO":"Compiler-Unions","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"tsc_node_16_17_1_Monaco":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_node_16_17_1_Monaco","TSPERF_JOB_HOST":"node@16.17.1","TSPERF_JOB_SCENARIO":"Monaco","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"tsc_node_16_17_1_Compiler_Unions":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_node_16_17_1_Compiler_Unions","TSPERF_JOB_HOST":"node@16.17.1","TSPERF_JOB_SCENARIO":"Compiler-Unions","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"tsserver_node_16_17_1_CompilerTSServer":{"TSPERF_JOB_KIND":"tsserver","TSPERF_JOB_NAME":"tsserver_node_16_17_1_CompilerTSServer","TSPERF_JOB_HOST":"node@16.17.1","TSPERF_JOB_SCENARIO":"CompilerTSServer","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"startup_node_16_17_1_tsserver_startup":{"TSPERF_JOB_KIND":"startup","TSPERF_JOB_NAME":"startup_node_16_17_1_tsserver_startup","TSPERF_JOB_HOST":"node@16.17.1","TSPERF_JOB_SCENARIO":"tsserver-startup","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"}}
+##vso[task.setvariable variable=MATRIX_ts_perf2;isOutput=true]{"tsc_node_20_5_1_Monaco":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_node_20_5_1_Monaco","TSPERF_JOB_HOST":"node@20.5.1","TSPERF_JOB_SCENARIO":"Monaco","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"tsc_node_20_5_1_Compiler_Unions":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_node_20_5_1_Compiler_Unions","TSPERF_JOB_HOST":"node@20.5.1","TSPERF_JOB_SCENARIO":"Compiler-Unions","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"tsc_node_18_15_0_Monaco":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_node_18_15_0_Monaco","TSPERF_JOB_HOST":"node@18.15.0","TSPERF_JOB_SCENARIO":"Monaco","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"tsc_node_18_15_0_Compiler_Unions":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_node_18_15_0_Compiler_Unions","TSPERF_JOB_HOST":"node@18.15.0","TSPERF_JOB_SCENARIO":"Compiler-Unions","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"tsc_node_16_17_1_Monaco":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_node_16_17_1_Monaco","TSPERF_JOB_HOST":"node@16.17.1","TSPERF_JOB_SCENARIO":"Monaco","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"tsc_node_16_17_1_Compiler_Unions":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_node_16_17_1_Compiler_Unions","TSPERF_JOB_HOST":"node@16.17.1","TSPERF_JOB_SCENARIO":"Compiler-Unions","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"tsserver_node_16_17_1_CompilerTSServer":{"TSPERF_JOB_KIND":"tsserver","TSPERF_JOB_NAME":"tsserver_node_16_17_1_CompilerTSServer","TSPERF_JOB_HOST":"node@16.17.1","TSPERF_JOB_SCENARIO":"CompilerTSServer","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"startup_node_16_17_1_tsserver_startup":{"TSPERF_JOB_KIND":"startup","TSPERF_JOB_NAME":"startup_node_16_17_1_tsserver_startup","TSPERF_JOB_HOST":"node@16.17.1","TSPERF_JOB_SCENARIO":"tsserver-startup","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"}}
+{
+    "tsc_node_20_5_1_Monaco": {
+        "TSPERF_JOB_KIND": "tsc",
+        "TSPERF_JOB_NAME": "tsc_node_20_5_1_Monaco",
+        "TSPERF_JOB_HOST": "node@20.5.1",
+        "TSPERF_JOB_SCENARIO": "Monaco",
+        "TSPERF_JOB_ITERATIONS": 6,
+        "TSPERF_JOB_LOCATION": "internal"
+    },
+    "tsc_node_20_5_1_Compiler_Unions": {
+        "TSPERF_JOB_KIND": "tsc",
+        "TSPERF_JOB_NAME": "tsc_node_20_5_1_Compiler_Unions",
+        "TSPERF_JOB_HOST": "node@20.5.1",
+        "TSPERF_JOB_SCENARIO": "Compiler-Unions",
+        "TSPERF_JOB_ITERATIONS": 6,
+        "TSPERF_JOB_LOCATION": "internal"
+    },
+    "tsc_node_18_15_0_Monaco": {
+        "TSPERF_JOB_KIND": "tsc",
+        "TSPERF_JOB_NAME": "tsc_node_18_15_0_Monaco",
+        "TSPERF_JOB_HOST": "node@18.15.0",
+        "TSPERF_JOB_SCENARIO": "Monaco",
+        "TSPERF_JOB_ITERATIONS": 6,
+        "TSPERF_JOB_LOCATION": "internal"
+    },
+    "tsc_node_18_15_0_Compiler_Unions": {
+        "TSPERF_JOB_KIND": "tsc",
+        "TSPERF_JOB_NAME": "tsc_node_18_15_0_Compiler_Unions",
+        "TSPERF_JOB_HOST": "node@18.15.0",
+        "TSPERF_JOB_SCENARIO": "Compiler-Unions",
+        "TSPERF_JOB_ITERATIONS": 6,
+        "TSPERF_JOB_LOCATION": "internal"
+    },
+    "tsc_node_16_17_1_Monaco": {
+        "TSPERF_JOB_KIND": "tsc",
+        "TSPERF_JOB_NAME": "tsc_node_16_17_1_Monaco",
+        "TSPERF_JOB_HOST": "node@16.17.1",
+        "TSPERF_JOB_SCENARIO": "Monaco",
+        "TSPERF_JOB_ITERATIONS": 6,
+        "TSPERF_JOB_LOCATION": "internal"
+    },
+    "tsc_node_16_17_1_Compiler_Unions": {
+        "TSPERF_JOB_KIND": "tsc",
+        "TSPERF_JOB_NAME": "tsc_node_16_17_1_Compiler_Unions",
+        "TSPERF_JOB_HOST": "node@16.17.1",
+        "TSPERF_JOB_SCENARIO": "Compiler-Unions",
+        "TSPERF_JOB_ITERATIONS": 6,
+        "TSPERF_JOB_LOCATION": "internal"
+    },
+    "tsserver_node_16_17_1_CompilerTSServer": {
+        "TSPERF_JOB_KIND": "tsserver",
+        "TSPERF_JOB_NAME": "tsserver_node_16_17_1_CompilerTSServer",
+        "TSPERF_JOB_HOST": "node@16.17.1",
+        "TSPERF_JOB_SCENARIO": "CompilerTSServer",
+        "TSPERF_JOB_ITERATIONS": 6,
+        "TSPERF_JOB_LOCATION": "internal"
+    },
+    "startup_node_16_17_1_tsserver_startup": {
+        "TSPERF_JOB_KIND": "startup",
+        "TSPERF_JOB_NAME": "startup_node_16_17_1_tsserver_startup",
+        "TSPERF_JOB_HOST": "node@16.17.1",
+        "TSPERF_JOB_SCENARIO": "tsserver-startup",
+        "TSPERF_JOB_ITERATIONS": 6,
+        "TSPERF_JOB_LOCATION": "internal"
+    }
+}
+setting output MATRIX_ts_perf3={"tsc_node_20_5_1_TFS":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_node_20_5_1_TFS","TSPERF_JOB_HOST":"node@20.5.1","TSPERF_JOB_SCENARIO":"TFS","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"tsc_node_20_5_1_xstate":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_node_20_5_1_xstate","TSPERF_JOB_HOST":"node@20.5.1","TSPERF_JOB_SCENARIO":"xstate","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"tsc_node_18_15_0_TFS":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_node_18_15_0_TFS","TSPERF_JOB_HOST":"node@18.15.0","TSPERF_JOB_SCENARIO":"TFS","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"tsc_node_18_15_0_xstate":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_node_18_15_0_xstate","TSPERF_JOB_HOST":"node@18.15.0","TSPERF_JOB_SCENARIO":"xstate","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"tsc_node_16_17_1_TFS":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_node_16_17_1_TFS","TSPERF_JOB_HOST":"node@16.17.1","TSPERF_JOB_SCENARIO":"TFS","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"tsc_node_16_17_1_xstate":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_node_16_17_1_xstate","TSPERF_JOB_HOST":"node@16.17.1","TSPERF_JOB_SCENARIO":"xstate","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"tsserver_node_16_17_1_xstateTSServer":{"TSPERF_JOB_KIND":"tsserver","TSPERF_JOB_NAME":"tsserver_node_16_17_1_xstateTSServer","TSPERF_JOB_HOST":"node@16.17.1","TSPERF_JOB_SCENARIO":"xstateTSServer","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"startup_node_16_17_1_tsserverlibrary_startup":{"TSPERF_JOB_KIND":"startup","TSPERF_JOB_NAME":"startup_node_16_17_1_tsserverlibrary_startup","TSPERF_JOB_HOST":"node@16.17.1","TSPERF_JOB_SCENARIO":"tsserverlibrary-startup","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"}}
+##vso[task.setvariable variable=MATRIX_ts_perf3;isOutput=true]{"tsc_node_20_5_1_TFS":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_node_20_5_1_TFS","TSPERF_JOB_HOST":"node@20.5.1","TSPERF_JOB_SCENARIO":"TFS","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"tsc_node_20_5_1_xstate":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_node_20_5_1_xstate","TSPERF_JOB_HOST":"node@20.5.1","TSPERF_JOB_SCENARIO":"xstate","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"tsc_node_18_15_0_TFS":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_node_18_15_0_TFS","TSPERF_JOB_HOST":"node@18.15.0","TSPERF_JOB_SCENARIO":"TFS","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"tsc_node_18_15_0_xstate":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_node_18_15_0_xstate","TSPERF_JOB_HOST":"node@18.15.0","TSPERF_JOB_SCENARIO":"xstate","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"tsc_node_16_17_1_TFS":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_node_16_17_1_TFS","TSPERF_JOB_HOST":"node@16.17.1","TSPERF_JOB_SCENARIO":"TFS","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"tsc_node_16_17_1_xstate":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_node_16_17_1_xstate","TSPERF_JOB_HOST":"node@16.17.1","TSPERF_JOB_SCENARIO":"xstate","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"tsserver_node_16_17_1_xstateTSServer":{"TSPERF_JOB_KIND":"tsserver","TSPERF_JOB_NAME":"tsserver_node_16_17_1_xstateTSServer","TSPERF_JOB_HOST":"node@16.17.1","TSPERF_JOB_SCENARIO":"xstateTSServer","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"startup_node_16_17_1_tsserverlibrary_startup":{"TSPERF_JOB_KIND":"startup","TSPERF_JOB_NAME":"startup_node_16_17_1_tsserverlibrary_startup","TSPERF_JOB_HOST":"node@16.17.1","TSPERF_JOB_SCENARIO":"tsserverlibrary-startup","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"}}
+{
+    "tsc_node_20_5_1_TFS": {
+        "TSPERF_JOB_KIND": "tsc",
+        "TSPERF_JOB_NAME": "tsc_node_20_5_1_TFS",
+        "TSPERF_JOB_HOST": "node@20.5.1",
+        "TSPERF_JOB_SCENARIO": "TFS",
+        "TSPERF_JOB_ITERATIONS": 6,
+        "TSPERF_JOB_LOCATION": "internal"
+    },
+    "tsc_node_20_5_1_xstate": {
+        "TSPERF_JOB_KIND": "tsc",
+        "TSPERF_JOB_NAME": "tsc_node_20_5_1_xstate",
+        "TSPERF_JOB_HOST": "node@20.5.1",
+        "TSPERF_JOB_SCENARIO": "xstate",
+        "TSPERF_JOB_ITERATIONS": 6,
+        "TSPERF_JOB_LOCATION": "internal"
+    },
+    "tsc_node_18_15_0_TFS": {
+        "TSPERF_JOB_KIND": "tsc",
+        "TSPERF_JOB_NAME": "tsc_node_18_15_0_TFS",
+        "TSPERF_JOB_HOST": "node@18.15.0",
+        "TSPERF_JOB_SCENARIO": "TFS",
+        "TSPERF_JOB_ITERATIONS": 6,
+        "TSPERF_JOB_LOCATION": "internal"
+    },
+    "tsc_node_18_15_0_xstate": {
+        "TSPERF_JOB_KIND": "tsc",
+        "TSPERF_JOB_NAME": "tsc_node_18_15_0_xstate",
+        "TSPERF_JOB_HOST": "node@18.15.0",
+        "TSPERF_JOB_SCENARIO": "xstate",
+        "TSPERF_JOB_ITERATIONS": 6,
+        "TSPERF_JOB_LOCATION": "internal"
+    },
+    "tsc_node_16_17_1_TFS": {
+        "TSPERF_JOB_KIND": "tsc",
+        "TSPERF_JOB_NAME": "tsc_node_16_17_1_TFS",
+        "TSPERF_JOB_HOST": "node@16.17.1",
+        "TSPERF_JOB_SCENARIO": "TFS",
+        "TSPERF_JOB_ITERATIONS": 6,
+        "TSPERF_JOB_LOCATION": "internal"
+    },
+    "tsc_node_16_17_1_xstate": {
+        "TSPERF_JOB_KIND": "tsc",
+        "TSPERF_JOB_NAME": "tsc_node_16_17_1_xstate",
+        "TSPERF_JOB_HOST": "node@16.17.1",
+        "TSPERF_JOB_SCENARIO": "xstate",
+        "TSPERF_JOB_ITERATIONS": 6,
+        "TSPERF_JOB_LOCATION": "internal"
+    },
+    "tsserver_node_16_17_1_xstateTSServer": {
+        "TSPERF_JOB_KIND": "tsserver",
+        "TSPERF_JOB_NAME": "tsserver_node_16_17_1_xstateTSServer",
+        "TSPERF_JOB_HOST": "node@16.17.1",
+        "TSPERF_JOB_SCENARIO": "xstateTSServer",
+        "TSPERF_JOB_ITERATIONS": 6,
+        "TSPERF_JOB_LOCATION": "internal"
+    },
+    "startup_node_16_17_1_tsserverlibrary_startup": {
+        "TSPERF_JOB_KIND": "startup",
+        "TSPERF_JOB_NAME": "startup_node_16_17_1_tsserverlibrary_startup",
+        "TSPERF_JOB_HOST": "node@16.17.1",
+        "TSPERF_JOB_SCENARIO": "tsserverlibrary-startup",
+        "TSPERF_JOB_ITERATIONS": 6,
+        "TSPERF_JOB_LOCATION": "internal"
+    }
+}
+setting output MATRIX_ts_perf4={}
+##vso[task.setvariable variable=MATRIX_ts_perf4;isOutput=true]{}
+{}
+setting output TSPERF_PROCESS_KINDS=tsc tsserver startup
+##vso[task.setvariable variable=TSPERF_PROCESS_KINDS;isOutput=true]tsc tsserver startup
+setting output TSPERF_PROCESS_LOCATIONS=internal
+##vso[task.setvariable variable=TSPERF_PROCESS_LOCATIONS;isOutput=true]internal"
+`;
+
+exports[`generateMatrix { preset: 'full', env: { USE_BASELINE_MACHINE: 'true' } } 2`] = `""`;
+
+exports[`generateMatrix { preset: 'full', env: { USE_BASELINE_MACHINE: 'true' } } 3`] = `0`;
+
+exports[`generateMatrix { preset: 'full', env: {} } 1`] = `
+"setting output MATRIX_any={"tsc_node_20_5_1_Angular":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_node_20_5_1_Angular","TSPERF_JOB_HOST":"node@20.5.1","TSPERF_JOB_SCENARIO":"Angular","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"tsc_node_20_5_1_Monaco":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_node_20_5_1_Monaco","TSPERF_JOB_HOST":"node@20.5.1","TSPERF_JOB_SCENARIO":"Monaco","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"tsc_node_20_5_1_TFS":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_node_20_5_1_TFS","TSPERF_JOB_HOST":"node@20.5.1","TSPERF_JOB_SCENARIO":"TFS","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"tsc_node_20_5_1_material_ui":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_node_20_5_1_material_ui","TSPERF_JOB_HOST":"node@20.5.1","TSPERF_JOB_SCENARIO":"material-ui","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"tsc_node_20_5_1_Compiler_Unions":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_node_20_5_1_Compiler_Unions","TSPERF_JOB_HOST":"node@20.5.1","TSPERF_JOB_SCENARIO":"Compiler-Unions","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"tsc_node_20_5_1_xstate":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_node_20_5_1_xstate","TSPERF_JOB_HOST":"node@20.5.1","TSPERF_JOB_SCENARIO":"xstate","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"tsc_node_18_15_0_Angular":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_node_18_15_0_Angular","TSPERF_JOB_HOST":"node@18.15.0","TSPERF_JOB_SCENARIO":"Angular","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"tsc_node_18_15_0_Monaco":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_node_18_15_0_Monaco","TSPERF_JOB_HOST":"node@18.15.0","TSPERF_JOB_SCENARIO":"Monaco","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"tsc_node_18_15_0_TFS":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_node_18_15_0_TFS","TSPERF_JOB_HOST":"node@18.15.0","TSPERF_JOB_SCENARIO":"TFS","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"tsc_node_18_15_0_material_ui":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_node_18_15_0_material_ui","TSPERF_JOB_HOST":"node@18.15.0","TSPERF_JOB_SCENARIO":"material-ui","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"tsc_node_18_15_0_Compiler_Unions":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_node_18_15_0_Compiler_Unions","TSPERF_JOB_HOST":"node@18.15.0","TSPERF_JOB_SCENARIO":"Compiler-Unions","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"tsc_node_18_15_0_xstate":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_node_18_15_0_xstate","TSPERF_JOB_HOST":"node@18.15.0","TSPERF_JOB_SCENARIO":"xstate","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"tsc_node_16_17_1_Angular":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_node_16_17_1_Angular","TSPERF_JOB_HOST":"node@16.17.1","TSPERF_JOB_SCENARIO":"Angular","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"tsc_node_16_17_1_Monaco":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_node_16_17_1_Monaco","TSPERF_JOB_HOST":"node@16.17.1","TSPERF_JOB_SCENARIO":"Monaco","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"tsc_node_16_17_1_TFS":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_node_16_17_1_TFS","TSPERF_JOB_HOST":"node@16.17.1","TSPERF_JOB_SCENARIO":"TFS","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"tsc_node_16_17_1_material_ui":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_node_16_17_1_material_ui","TSPERF_JOB_HOST":"node@16.17.1","TSPERF_JOB_SCENARIO":"material-ui","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"tsc_node_16_17_1_Compiler_Unions":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_node_16_17_1_Compiler_Unions","TSPERF_JOB_HOST":"node@16.17.1","TSPERF_JOB_SCENARIO":"Compiler-Unions","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"tsc_node_16_17_1_xstate":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_node_16_17_1_xstate","TSPERF_JOB_HOST":"node@16.17.1","TSPERF_JOB_SCENARIO":"xstate","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"tsserver_node_16_17_1_Compiler_UnionsTSServer":{"TSPERF_JOB_KIND":"tsserver","TSPERF_JOB_NAME":"tsserver_node_16_17_1_Compiler_UnionsTSServer","TSPERF_JOB_HOST":"node@16.17.1","TSPERF_JOB_SCENARIO":"Compiler-UnionsTSServer","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"tsserver_node_16_17_1_CompilerTSServer":{"TSPERF_JOB_KIND":"tsserver","TSPERF_JOB_NAME":"tsserver_node_16_17_1_CompilerTSServer","TSPERF_JOB_HOST":"node@16.17.1","TSPERF_JOB_SCENARIO":"CompilerTSServer","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"tsserver_node_16_17_1_xstateTSServer":{"TSPERF_JOB_KIND":"tsserver","TSPERF_JOB_NAME":"tsserver_node_16_17_1_xstateTSServer","TSPERF_JOB_HOST":"node@16.17.1","TSPERF_JOB_SCENARIO":"xstateTSServer","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"startup_node_16_17_1_tsc_startup":{"TSPERF_JOB_KIND":"startup","TSPERF_JOB_NAME":"startup_node_16_17_1_tsc_startup","TSPERF_JOB_HOST":"node@16.17.1","TSPERF_JOB_SCENARIO":"tsc-startup","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"startup_node_16_17_1_tsserver_startup":{"TSPERF_JOB_KIND":"startup","TSPERF_JOB_NAME":"startup_node_16_17_1_tsserver_startup","TSPERF_JOB_HOST":"node@16.17.1","TSPERF_JOB_SCENARIO":"tsserver-startup","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"startup_node_16_17_1_tsserverlibrary_startup":{"TSPERF_JOB_KIND":"startup","TSPERF_JOB_NAME":"startup_node_16_17_1_tsserverlibrary_startup","TSPERF_JOB_HOST":"node@16.17.1","TSPERF_JOB_SCENARIO":"tsserverlibrary-startup","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"startup_node_16_17_1_typescript_startup":{"TSPERF_JOB_KIND":"startup","TSPERF_JOB_NAME":"startup_node_16_17_1_typescript_startup","TSPERF_JOB_HOST":"node@16.17.1","TSPERF_JOB_SCENARIO":"typescript-startup","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"}}
+##vso[task.setvariable variable=MATRIX_any;isOutput=true]{"tsc_node_20_5_1_Angular":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_node_20_5_1_Angular","TSPERF_JOB_HOST":"node@20.5.1","TSPERF_JOB_SCENARIO":"Angular","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"tsc_node_20_5_1_Monaco":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_node_20_5_1_Monaco","TSPERF_JOB_HOST":"node@20.5.1","TSPERF_JOB_SCENARIO":"Monaco","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"tsc_node_20_5_1_TFS":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_node_20_5_1_TFS","TSPERF_JOB_HOST":"node@20.5.1","TSPERF_JOB_SCENARIO":"TFS","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"tsc_node_20_5_1_material_ui":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_node_20_5_1_material_ui","TSPERF_JOB_HOST":"node@20.5.1","TSPERF_JOB_SCENARIO":"material-ui","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"tsc_node_20_5_1_Compiler_Unions":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_node_20_5_1_Compiler_Unions","TSPERF_JOB_HOST":"node@20.5.1","TSPERF_JOB_SCENARIO":"Compiler-Unions","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"tsc_node_20_5_1_xstate":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_node_20_5_1_xstate","TSPERF_JOB_HOST":"node@20.5.1","TSPERF_JOB_SCENARIO":"xstate","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"tsc_node_18_15_0_Angular":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_node_18_15_0_Angular","TSPERF_JOB_HOST":"node@18.15.0","TSPERF_JOB_SCENARIO":"Angular","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"tsc_node_18_15_0_Monaco":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_node_18_15_0_Monaco","TSPERF_JOB_HOST":"node@18.15.0","TSPERF_JOB_SCENARIO":"Monaco","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"tsc_node_18_15_0_TFS":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_node_18_15_0_TFS","TSPERF_JOB_HOST":"node@18.15.0","TSPERF_JOB_SCENARIO":"TFS","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"tsc_node_18_15_0_material_ui":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_node_18_15_0_material_ui","TSPERF_JOB_HOST":"node@18.15.0","TSPERF_JOB_SCENARIO":"material-ui","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"tsc_node_18_15_0_Compiler_Unions":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_node_18_15_0_Compiler_Unions","TSPERF_JOB_HOST":"node@18.15.0","TSPERF_JOB_SCENARIO":"Compiler-Unions","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"tsc_node_18_15_0_xstate":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_node_18_15_0_xstate","TSPERF_JOB_HOST":"node@18.15.0","TSPERF_JOB_SCENARIO":"xstate","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"tsc_node_16_17_1_Angular":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_node_16_17_1_Angular","TSPERF_JOB_HOST":"node@16.17.1","TSPERF_JOB_SCENARIO":"Angular","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"tsc_node_16_17_1_Monaco":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_node_16_17_1_Monaco","TSPERF_JOB_HOST":"node@16.17.1","TSPERF_JOB_SCENARIO":"Monaco","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"tsc_node_16_17_1_TFS":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_node_16_17_1_TFS","TSPERF_JOB_HOST":"node@16.17.1","TSPERF_JOB_SCENARIO":"TFS","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"tsc_node_16_17_1_material_ui":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_node_16_17_1_material_ui","TSPERF_JOB_HOST":"node@16.17.1","TSPERF_JOB_SCENARIO":"material-ui","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"tsc_node_16_17_1_Compiler_Unions":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_node_16_17_1_Compiler_Unions","TSPERF_JOB_HOST":"node@16.17.1","TSPERF_JOB_SCENARIO":"Compiler-Unions","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"tsc_node_16_17_1_xstate":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_node_16_17_1_xstate","TSPERF_JOB_HOST":"node@16.17.1","TSPERF_JOB_SCENARIO":"xstate","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"tsserver_node_16_17_1_Compiler_UnionsTSServer":{"TSPERF_JOB_KIND":"tsserver","TSPERF_JOB_NAME":"tsserver_node_16_17_1_Compiler_UnionsTSServer","TSPERF_JOB_HOST":"node@16.17.1","TSPERF_JOB_SCENARIO":"Compiler-UnionsTSServer","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"tsserver_node_16_17_1_CompilerTSServer":{"TSPERF_JOB_KIND":"tsserver","TSPERF_JOB_NAME":"tsserver_node_16_17_1_CompilerTSServer","TSPERF_JOB_HOST":"node@16.17.1","TSPERF_JOB_SCENARIO":"CompilerTSServer","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"tsserver_node_16_17_1_xstateTSServer":{"TSPERF_JOB_KIND":"tsserver","TSPERF_JOB_NAME":"tsserver_node_16_17_1_xstateTSServer","TSPERF_JOB_HOST":"node@16.17.1","TSPERF_JOB_SCENARIO":"xstateTSServer","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"startup_node_16_17_1_tsc_startup":{"TSPERF_JOB_KIND":"startup","TSPERF_JOB_NAME":"startup_node_16_17_1_tsc_startup","TSPERF_JOB_HOST":"node@16.17.1","TSPERF_JOB_SCENARIO":"tsc-startup","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"startup_node_16_17_1_tsserver_startup":{"TSPERF_JOB_KIND":"startup","TSPERF_JOB_NAME":"startup_node_16_17_1_tsserver_startup","TSPERF_JOB_HOST":"node@16.17.1","TSPERF_JOB_SCENARIO":"tsserver-startup","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"startup_node_16_17_1_tsserverlibrary_startup":{"TSPERF_JOB_KIND":"startup","TSPERF_JOB_NAME":"startup_node_16_17_1_tsserverlibrary_startup","TSPERF_JOB_HOST":"node@16.17.1","TSPERF_JOB_SCENARIO":"tsserverlibrary-startup","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"startup_node_16_17_1_typescript_startup":{"TSPERF_JOB_KIND":"startup","TSPERF_JOB_NAME":"startup_node_16_17_1_typescript_startup","TSPERF_JOB_HOST":"node@16.17.1","TSPERF_JOB_SCENARIO":"typescript-startup","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"}}
+{
+    "tsc_node_20_5_1_Angular": {
+        "TSPERF_JOB_KIND": "tsc",
+        "TSPERF_JOB_NAME": "tsc_node_20_5_1_Angular",
+        "TSPERF_JOB_HOST": "node@20.5.1",
+        "TSPERF_JOB_SCENARIO": "Angular",
+        "TSPERF_JOB_ITERATIONS": 6,
+        "TSPERF_JOB_LOCATION": "internal"
+    },
+    "tsc_node_20_5_1_Monaco": {
+        "TSPERF_JOB_KIND": "tsc",
+        "TSPERF_JOB_NAME": "tsc_node_20_5_1_Monaco",
+        "TSPERF_JOB_HOST": "node@20.5.1",
+        "TSPERF_JOB_SCENARIO": "Monaco",
+        "TSPERF_JOB_ITERATIONS": 6,
+        "TSPERF_JOB_LOCATION": "internal"
+    },
+    "tsc_node_20_5_1_TFS": {
+        "TSPERF_JOB_KIND": "tsc",
+        "TSPERF_JOB_NAME": "tsc_node_20_5_1_TFS",
+        "TSPERF_JOB_HOST": "node@20.5.1",
+        "TSPERF_JOB_SCENARIO": "TFS",
+        "TSPERF_JOB_ITERATIONS": 6,
+        "TSPERF_JOB_LOCATION": "internal"
+    },
+    "tsc_node_20_5_1_material_ui": {
+        "TSPERF_JOB_KIND": "tsc",
+        "TSPERF_JOB_NAME": "tsc_node_20_5_1_material_ui",
+        "TSPERF_JOB_HOST": "node@20.5.1",
+        "TSPERF_JOB_SCENARIO": "material-ui",
+        "TSPERF_JOB_ITERATIONS": 6,
+        "TSPERF_JOB_LOCATION": "internal"
+    },
+    "tsc_node_20_5_1_Compiler_Unions": {
+        "TSPERF_JOB_KIND": "tsc",
+        "TSPERF_JOB_NAME": "tsc_node_20_5_1_Compiler_Unions",
+        "TSPERF_JOB_HOST": "node@20.5.1",
+        "TSPERF_JOB_SCENARIO": "Compiler-Unions",
+        "TSPERF_JOB_ITERATIONS": 6,
+        "TSPERF_JOB_LOCATION": "internal"
+    },
+    "tsc_node_20_5_1_xstate": {
+        "TSPERF_JOB_KIND": "tsc",
+        "TSPERF_JOB_NAME": "tsc_node_20_5_1_xstate",
+        "TSPERF_JOB_HOST": "node@20.5.1",
+        "TSPERF_JOB_SCENARIO": "xstate",
+        "TSPERF_JOB_ITERATIONS": 6,
+        "TSPERF_JOB_LOCATION": "internal"
+    },
+    "tsc_node_18_15_0_Angular": {
+        "TSPERF_JOB_KIND": "tsc",
+        "TSPERF_JOB_NAME": "tsc_node_18_15_0_Angular",
+        "TSPERF_JOB_HOST": "node@18.15.0",
+        "TSPERF_JOB_SCENARIO": "Angular",
+        "TSPERF_JOB_ITERATIONS": 6,
+        "TSPERF_JOB_LOCATION": "internal"
+    },
+    "tsc_node_18_15_0_Monaco": {
+        "TSPERF_JOB_KIND": "tsc",
+        "TSPERF_JOB_NAME": "tsc_node_18_15_0_Monaco",
+        "TSPERF_JOB_HOST": "node@18.15.0",
+        "TSPERF_JOB_SCENARIO": "Monaco",
+        "TSPERF_JOB_ITERATIONS": 6,
+        "TSPERF_JOB_LOCATION": "internal"
+    },
+    "tsc_node_18_15_0_TFS": {
+        "TSPERF_JOB_KIND": "tsc",
+        "TSPERF_JOB_NAME": "tsc_node_18_15_0_TFS",
+        "TSPERF_JOB_HOST": "node@18.15.0",
+        "TSPERF_JOB_SCENARIO": "TFS",
+        "TSPERF_JOB_ITERATIONS": 6,
+        "TSPERF_JOB_LOCATION": "internal"
+    },
+    "tsc_node_18_15_0_material_ui": {
+        "TSPERF_JOB_KIND": "tsc",
+        "TSPERF_JOB_NAME": "tsc_node_18_15_0_material_ui",
+        "TSPERF_JOB_HOST": "node@18.15.0",
+        "TSPERF_JOB_SCENARIO": "material-ui",
+        "TSPERF_JOB_ITERATIONS": 6,
+        "TSPERF_JOB_LOCATION": "internal"
+    },
+    "tsc_node_18_15_0_Compiler_Unions": {
+        "TSPERF_JOB_KIND": "tsc",
+        "TSPERF_JOB_NAME": "tsc_node_18_15_0_Compiler_Unions",
+        "TSPERF_JOB_HOST": "node@18.15.0",
+        "TSPERF_JOB_SCENARIO": "Compiler-Unions",
+        "TSPERF_JOB_ITERATIONS": 6,
+        "TSPERF_JOB_LOCATION": "internal"
+    },
+    "tsc_node_18_15_0_xstate": {
+        "TSPERF_JOB_KIND": "tsc",
+        "TSPERF_JOB_NAME": "tsc_node_18_15_0_xstate",
+        "TSPERF_JOB_HOST": "node@18.15.0",
+        "TSPERF_JOB_SCENARIO": "xstate",
+        "TSPERF_JOB_ITERATIONS": 6,
+        "TSPERF_JOB_LOCATION": "internal"
+    },
+    "tsc_node_16_17_1_Angular": {
+        "TSPERF_JOB_KIND": "tsc",
+        "TSPERF_JOB_NAME": "tsc_node_16_17_1_Angular",
+        "TSPERF_JOB_HOST": "node@16.17.1",
+        "TSPERF_JOB_SCENARIO": "Angular",
+        "TSPERF_JOB_ITERATIONS": 6,
+        "TSPERF_JOB_LOCATION": "internal"
+    },
+    "tsc_node_16_17_1_Monaco": {
+        "TSPERF_JOB_KIND": "tsc",
+        "TSPERF_JOB_NAME": "tsc_node_16_17_1_Monaco",
+        "TSPERF_JOB_HOST": "node@16.17.1",
+        "TSPERF_JOB_SCENARIO": "Monaco",
+        "TSPERF_JOB_ITERATIONS": 6,
+        "TSPERF_JOB_LOCATION": "internal"
+    },
+    "tsc_node_16_17_1_TFS": {
+        "TSPERF_JOB_KIND": "tsc",
+        "TSPERF_JOB_NAME": "tsc_node_16_17_1_TFS",
+        "TSPERF_JOB_HOST": "node@16.17.1",
+        "TSPERF_JOB_SCENARIO": "TFS",
+        "TSPERF_JOB_ITERATIONS": 6,
+        "TSPERF_JOB_LOCATION": "internal"
+    },
+    "tsc_node_16_17_1_material_ui": {
+        "TSPERF_JOB_KIND": "tsc",
+        "TSPERF_JOB_NAME": "tsc_node_16_17_1_material_ui",
+        "TSPERF_JOB_HOST": "node@16.17.1",
+        "TSPERF_JOB_SCENARIO": "material-ui",
+        "TSPERF_JOB_ITERATIONS": 6,
+        "TSPERF_JOB_LOCATION": "internal"
+    },
+    "tsc_node_16_17_1_Compiler_Unions": {
+        "TSPERF_JOB_KIND": "tsc",
+        "TSPERF_JOB_NAME": "tsc_node_16_17_1_Compiler_Unions",
+        "TSPERF_JOB_HOST": "node@16.17.1",
+        "TSPERF_JOB_SCENARIO": "Compiler-Unions",
+        "TSPERF_JOB_ITERATIONS": 6,
+        "TSPERF_JOB_LOCATION": "internal"
+    },
+    "tsc_node_16_17_1_xstate": {
+        "TSPERF_JOB_KIND": "tsc",
+        "TSPERF_JOB_NAME": "tsc_node_16_17_1_xstate",
+        "TSPERF_JOB_HOST": "node@16.17.1",
+        "TSPERF_JOB_SCENARIO": "xstate",
+        "TSPERF_JOB_ITERATIONS": 6,
+        "TSPERF_JOB_LOCATION": "internal"
+    },
+    "tsserver_node_16_17_1_Compiler_UnionsTSServer": {
+        "TSPERF_JOB_KIND": "tsserver",
+        "TSPERF_JOB_NAME": "tsserver_node_16_17_1_Compiler_UnionsTSServer",
+        "TSPERF_JOB_HOST": "node@16.17.1",
+        "TSPERF_JOB_SCENARIO": "Compiler-UnionsTSServer",
+        "TSPERF_JOB_ITERATIONS": 6,
+        "TSPERF_JOB_LOCATION": "internal"
+    },
+    "tsserver_node_16_17_1_CompilerTSServer": {
+        "TSPERF_JOB_KIND": "tsserver",
+        "TSPERF_JOB_NAME": "tsserver_node_16_17_1_CompilerTSServer",
+        "TSPERF_JOB_HOST": "node@16.17.1",
+        "TSPERF_JOB_SCENARIO": "CompilerTSServer",
+        "TSPERF_JOB_ITERATIONS": 6,
+        "TSPERF_JOB_LOCATION": "internal"
+    },
+    "tsserver_node_16_17_1_xstateTSServer": {
+        "TSPERF_JOB_KIND": "tsserver",
+        "TSPERF_JOB_NAME": "tsserver_node_16_17_1_xstateTSServer",
+        "TSPERF_JOB_HOST": "node@16.17.1",
+        "TSPERF_JOB_SCENARIO": "xstateTSServer",
+        "TSPERF_JOB_ITERATIONS": 6,
+        "TSPERF_JOB_LOCATION": "internal"
+    },
+    "startup_node_16_17_1_tsc_startup": {
+        "TSPERF_JOB_KIND": "startup",
+        "TSPERF_JOB_NAME": "startup_node_16_17_1_tsc_startup",
+        "TSPERF_JOB_HOST": "node@16.17.1",
+        "TSPERF_JOB_SCENARIO": "tsc-startup",
+        "TSPERF_JOB_ITERATIONS": 6,
+        "TSPERF_JOB_LOCATION": "internal"
+    },
+    "startup_node_16_17_1_tsserver_startup": {
+        "TSPERF_JOB_KIND": "startup",
+        "TSPERF_JOB_NAME": "startup_node_16_17_1_tsserver_startup",
+        "TSPERF_JOB_HOST": "node@16.17.1",
+        "TSPERF_JOB_SCENARIO": "tsserver-startup",
+        "TSPERF_JOB_ITERATIONS": 6,
+        "TSPERF_JOB_LOCATION": "internal"
+    },
+    "startup_node_16_17_1_tsserverlibrary_startup": {
+        "TSPERF_JOB_KIND": "startup",
+        "TSPERF_JOB_NAME": "startup_node_16_17_1_tsserverlibrary_startup",
+        "TSPERF_JOB_HOST": "node@16.17.1",
+        "TSPERF_JOB_SCENARIO": "tsserverlibrary-startup",
+        "TSPERF_JOB_ITERATIONS": 6,
+        "TSPERF_JOB_LOCATION": "internal"
+    },
+    "startup_node_16_17_1_typescript_startup": {
+        "TSPERF_JOB_KIND": "startup",
+        "TSPERF_JOB_NAME": "startup_node_16_17_1_typescript_startup",
+        "TSPERF_JOB_HOST": "node@16.17.1",
+        "TSPERF_JOB_SCENARIO": "typescript-startup",
+        "TSPERF_JOB_ITERATIONS": 6,
+        "TSPERF_JOB_LOCATION": "internal"
+    }
+}
+setting output MATRIX_ts_perf1={}
+##vso[task.setvariable variable=MATRIX_ts_perf1;isOutput=true]{}
+{}
+setting output MATRIX_ts_perf2={}
+##vso[task.setvariable variable=MATRIX_ts_perf2;isOutput=true]{}
+{}
+setting output MATRIX_ts_perf3={}
+##vso[task.setvariable variable=MATRIX_ts_perf3;isOutput=true]{}
+{}
+setting output MATRIX_ts_perf4={}
+##vso[task.setvariable variable=MATRIX_ts_perf4;isOutput=true]{}
+{}
+setting output TSPERF_PROCESS_KINDS=tsc tsserver startup
+##vso[task.setvariable variable=TSPERF_PROCESS_KINDS;isOutput=true]tsc tsserver startup
+setting output TSPERF_PROCESS_LOCATIONS=internal
+##vso[task.setvariable variable=TSPERF_PROCESS_LOCATIONS;isOutput=true]internal"
+`;
+
+exports[`generateMatrix { preset: 'full', env: {} } 2`] = `""`;
+
+exports[`generateMatrix { preset: 'full', env: {} } 3`] = `0`;
+
+exports[`generateMatrix { preset: 'public', env: {} } 1`] = `
+"setting output MATRIX_any={"tsc_node_20_5_1_vscode":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_node_20_5_1_vscode","TSPERF_JOB_HOST":"node@20.5.1","TSPERF_JOB_SCENARIO":"vscode","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"public"},"tsc_node_20_5_1_self_compiler":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_node_20_5_1_self_compiler","TSPERF_JOB_HOST":"node@20.5.1","TSPERF_JOB_SCENARIO":"self-compiler","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"public"},"tsc_node_20_5_1_self_build_src":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_node_20_5_1_self_build_src","TSPERF_JOB_HOST":"node@20.5.1","TSPERF_JOB_SCENARIO":"self-build-src","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"public"},"tsc_node_20_5_1_mui_docs":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_node_20_5_1_mui_docs","TSPERF_JOB_HOST":"node@20.5.1","TSPERF_JOB_SCENARIO":"mui-docs","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"public"},"tsc_node_20_5_1_webpack":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_node_20_5_1_webpack","TSPERF_JOB_HOST":"node@20.5.1","TSPERF_JOB_SCENARIO":"webpack","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"public"}}
+##vso[task.setvariable variable=MATRIX_any;isOutput=true]{"tsc_node_20_5_1_vscode":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_node_20_5_1_vscode","TSPERF_JOB_HOST":"node@20.5.1","TSPERF_JOB_SCENARIO":"vscode","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"public"},"tsc_node_20_5_1_self_compiler":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_node_20_5_1_self_compiler","TSPERF_JOB_HOST":"node@20.5.1","TSPERF_JOB_SCENARIO":"self-compiler","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"public"},"tsc_node_20_5_1_self_build_src":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_node_20_5_1_self_build_src","TSPERF_JOB_HOST":"node@20.5.1","TSPERF_JOB_SCENARIO":"self-build-src","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"public"},"tsc_node_20_5_1_mui_docs":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_node_20_5_1_mui_docs","TSPERF_JOB_HOST":"node@20.5.1","TSPERF_JOB_SCENARIO":"mui-docs","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"public"},"tsc_node_20_5_1_webpack":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_node_20_5_1_webpack","TSPERF_JOB_HOST":"node@20.5.1","TSPERF_JOB_SCENARIO":"webpack","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"public"}}
+{
+    "tsc_node_20_5_1_vscode": {
+        "TSPERF_JOB_KIND": "tsc",
+        "TSPERF_JOB_NAME": "tsc_node_20_5_1_vscode",
+        "TSPERF_JOB_HOST": "node@20.5.1",
+        "TSPERF_JOB_SCENARIO": "vscode",
+        "TSPERF_JOB_ITERATIONS": 6,
+        "TSPERF_JOB_LOCATION": "public"
+    },
+    "tsc_node_20_5_1_self_compiler": {
+        "TSPERF_JOB_KIND": "tsc",
+        "TSPERF_JOB_NAME": "tsc_node_20_5_1_self_compiler",
+        "TSPERF_JOB_HOST": "node@20.5.1",
+        "TSPERF_JOB_SCENARIO": "self-compiler",
+        "TSPERF_JOB_ITERATIONS": 6,
+        "TSPERF_JOB_LOCATION": "public"
+    },
+    "tsc_node_20_5_1_self_build_src": {
+        "TSPERF_JOB_KIND": "tsc",
+        "TSPERF_JOB_NAME": "tsc_node_20_5_1_self_build_src",
+        "TSPERF_JOB_HOST": "node@20.5.1",
+        "TSPERF_JOB_SCENARIO": "self-build-src",
+        "TSPERF_JOB_ITERATIONS": 6,
+        "TSPERF_JOB_LOCATION": "public"
+    },
+    "tsc_node_20_5_1_mui_docs": {
+        "TSPERF_JOB_KIND": "tsc",
+        "TSPERF_JOB_NAME": "tsc_node_20_5_1_mui_docs",
+        "TSPERF_JOB_HOST": "node@20.5.1",
+        "TSPERF_JOB_SCENARIO": "mui-docs",
+        "TSPERF_JOB_ITERATIONS": 6,
+        "TSPERF_JOB_LOCATION": "public"
+    },
+    "tsc_node_20_5_1_webpack": {
+        "TSPERF_JOB_KIND": "tsc",
+        "TSPERF_JOB_NAME": "tsc_node_20_5_1_webpack",
+        "TSPERF_JOB_HOST": "node@20.5.1",
+        "TSPERF_JOB_SCENARIO": "webpack",
+        "TSPERF_JOB_ITERATIONS": 6,
+        "TSPERF_JOB_LOCATION": "public"
+    }
+}
+setting output MATRIX_ts_perf1={}
+##vso[task.setvariable variable=MATRIX_ts_perf1;isOutput=true]{}
+{}
+setting output MATRIX_ts_perf2={}
+##vso[task.setvariable variable=MATRIX_ts_perf2;isOutput=true]{}
+{}
+setting output MATRIX_ts_perf3={}
+##vso[task.setvariable variable=MATRIX_ts_perf3;isOutput=true]{}
+{}
+setting output MATRIX_ts_perf4={}
+##vso[task.setvariable variable=MATRIX_ts_perf4;isOutput=true]{}
+{}
+setting output TSPERF_PROCESS_KINDS=tsc
+##vso[task.setvariable variable=TSPERF_PROCESS_KINDS;isOutput=true]tsc
+setting output TSPERF_PROCESS_LOCATIONS=public
+##vso[task.setvariable variable=TSPERF_PROCESS_LOCATIONS;isOutput=true]public"
+`;
+
+exports[`generateMatrix { preset: 'public', env: {} } 2`] = `""`;
+
+exports[`generateMatrix { preset: 'public', env: {} } 3`] = `0`;
+
+exports[`generateMatrix { preset: 'regular', env: {} } 1`] = `
+"setting output MATRIX_any={"tsc_node_18_15_0_Angular":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_node_18_15_0_Angular","TSPERF_JOB_HOST":"node@18.15.0","TSPERF_JOB_SCENARIO":"Angular","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"tsc_node_18_15_0_Monaco":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_node_18_15_0_Monaco","TSPERF_JOB_HOST":"node@18.15.0","TSPERF_JOB_SCENARIO":"Monaco","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"tsc_node_18_15_0_TFS":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_node_18_15_0_TFS","TSPERF_JOB_HOST":"node@18.15.0","TSPERF_JOB_SCENARIO":"TFS","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"tsc_node_18_15_0_material_ui":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_node_18_15_0_material_ui","TSPERF_JOB_HOST":"node@18.15.0","TSPERF_JOB_SCENARIO":"material-ui","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"tsc_node_18_15_0_Compiler_Unions":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_node_18_15_0_Compiler_Unions","TSPERF_JOB_HOST":"node@18.15.0","TSPERF_JOB_SCENARIO":"Compiler-Unions","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"tsc_node_18_15_0_xstate":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_node_18_15_0_xstate","TSPERF_JOB_HOST":"node@18.15.0","TSPERF_JOB_SCENARIO":"xstate","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"tsserver_node_18_15_0_Compiler_UnionsTSServer":{"TSPERF_JOB_KIND":"tsserver","TSPERF_JOB_NAME":"tsserver_node_18_15_0_Compiler_UnionsTSServer","TSPERF_JOB_HOST":"node@18.15.0","TSPERF_JOB_SCENARIO":"Compiler-UnionsTSServer","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"tsserver_node_18_15_0_CompilerTSServer":{"TSPERF_JOB_KIND":"tsserver","TSPERF_JOB_NAME":"tsserver_node_18_15_0_CompilerTSServer","TSPERF_JOB_HOST":"node@18.15.0","TSPERF_JOB_SCENARIO":"CompilerTSServer","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"tsserver_node_18_15_0_xstateTSServer":{"TSPERF_JOB_KIND":"tsserver","TSPERF_JOB_NAME":"tsserver_node_18_15_0_xstateTSServer","TSPERF_JOB_HOST":"node@18.15.0","TSPERF_JOB_SCENARIO":"xstateTSServer","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"startup_node_18_15_0_tsc_startup":{"TSPERF_JOB_KIND":"startup","TSPERF_JOB_NAME":"startup_node_18_15_0_tsc_startup","TSPERF_JOB_HOST":"node@18.15.0","TSPERF_JOB_SCENARIO":"tsc-startup","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"startup_node_18_15_0_tsserver_startup":{"TSPERF_JOB_KIND":"startup","TSPERF_JOB_NAME":"startup_node_18_15_0_tsserver_startup","TSPERF_JOB_HOST":"node@18.15.0","TSPERF_JOB_SCENARIO":"tsserver-startup","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"startup_node_18_15_0_tsserverlibrary_startup":{"TSPERF_JOB_KIND":"startup","TSPERF_JOB_NAME":"startup_node_18_15_0_tsserverlibrary_startup","TSPERF_JOB_HOST":"node@18.15.0","TSPERF_JOB_SCENARIO":"tsserverlibrary-startup","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"startup_node_18_15_0_typescript_startup":{"TSPERF_JOB_KIND":"startup","TSPERF_JOB_NAME":"startup_node_18_15_0_typescript_startup","TSPERF_JOB_HOST":"node@18.15.0","TSPERF_JOB_SCENARIO":"typescript-startup","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"}}
+##vso[task.setvariable variable=MATRIX_any;isOutput=true]{"tsc_node_18_15_0_Angular":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_node_18_15_0_Angular","TSPERF_JOB_HOST":"node@18.15.0","TSPERF_JOB_SCENARIO":"Angular","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"tsc_node_18_15_0_Monaco":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_node_18_15_0_Monaco","TSPERF_JOB_HOST":"node@18.15.0","TSPERF_JOB_SCENARIO":"Monaco","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"tsc_node_18_15_0_TFS":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_node_18_15_0_TFS","TSPERF_JOB_HOST":"node@18.15.0","TSPERF_JOB_SCENARIO":"TFS","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"tsc_node_18_15_0_material_ui":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_node_18_15_0_material_ui","TSPERF_JOB_HOST":"node@18.15.0","TSPERF_JOB_SCENARIO":"material-ui","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"tsc_node_18_15_0_Compiler_Unions":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_node_18_15_0_Compiler_Unions","TSPERF_JOB_HOST":"node@18.15.0","TSPERF_JOB_SCENARIO":"Compiler-Unions","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"tsc_node_18_15_0_xstate":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_node_18_15_0_xstate","TSPERF_JOB_HOST":"node@18.15.0","TSPERF_JOB_SCENARIO":"xstate","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"tsserver_node_18_15_0_Compiler_UnionsTSServer":{"TSPERF_JOB_KIND":"tsserver","TSPERF_JOB_NAME":"tsserver_node_18_15_0_Compiler_UnionsTSServer","TSPERF_JOB_HOST":"node@18.15.0","TSPERF_JOB_SCENARIO":"Compiler-UnionsTSServer","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"tsserver_node_18_15_0_CompilerTSServer":{"TSPERF_JOB_KIND":"tsserver","TSPERF_JOB_NAME":"tsserver_node_18_15_0_CompilerTSServer","TSPERF_JOB_HOST":"node@18.15.0","TSPERF_JOB_SCENARIO":"CompilerTSServer","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"tsserver_node_18_15_0_xstateTSServer":{"TSPERF_JOB_KIND":"tsserver","TSPERF_JOB_NAME":"tsserver_node_18_15_0_xstateTSServer","TSPERF_JOB_HOST":"node@18.15.0","TSPERF_JOB_SCENARIO":"xstateTSServer","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"startup_node_18_15_0_tsc_startup":{"TSPERF_JOB_KIND":"startup","TSPERF_JOB_NAME":"startup_node_18_15_0_tsc_startup","TSPERF_JOB_HOST":"node@18.15.0","TSPERF_JOB_SCENARIO":"tsc-startup","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"startup_node_18_15_0_tsserver_startup":{"TSPERF_JOB_KIND":"startup","TSPERF_JOB_NAME":"startup_node_18_15_0_tsserver_startup","TSPERF_JOB_HOST":"node@18.15.0","TSPERF_JOB_SCENARIO":"tsserver-startup","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"startup_node_18_15_0_tsserverlibrary_startup":{"TSPERF_JOB_KIND":"startup","TSPERF_JOB_NAME":"startup_node_18_15_0_tsserverlibrary_startup","TSPERF_JOB_HOST":"node@18.15.0","TSPERF_JOB_SCENARIO":"tsserverlibrary-startup","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"startup_node_18_15_0_typescript_startup":{"TSPERF_JOB_KIND":"startup","TSPERF_JOB_NAME":"startup_node_18_15_0_typescript_startup","TSPERF_JOB_HOST":"node@18.15.0","TSPERF_JOB_SCENARIO":"typescript-startup","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"}}
+{
+    "tsc_node_18_15_0_Angular": {
+        "TSPERF_JOB_KIND": "tsc",
+        "TSPERF_JOB_NAME": "tsc_node_18_15_0_Angular",
+        "TSPERF_JOB_HOST": "node@18.15.0",
+        "TSPERF_JOB_SCENARIO": "Angular",
+        "TSPERF_JOB_ITERATIONS": 6,
+        "TSPERF_JOB_LOCATION": "internal"
+    },
+    "tsc_node_18_15_0_Monaco": {
+        "TSPERF_JOB_KIND": "tsc",
+        "TSPERF_JOB_NAME": "tsc_node_18_15_0_Monaco",
+        "TSPERF_JOB_HOST": "node@18.15.0",
+        "TSPERF_JOB_SCENARIO": "Monaco",
+        "TSPERF_JOB_ITERATIONS": 6,
+        "TSPERF_JOB_LOCATION": "internal"
+    },
+    "tsc_node_18_15_0_TFS": {
+        "TSPERF_JOB_KIND": "tsc",
+        "TSPERF_JOB_NAME": "tsc_node_18_15_0_TFS",
+        "TSPERF_JOB_HOST": "node@18.15.0",
+        "TSPERF_JOB_SCENARIO": "TFS",
+        "TSPERF_JOB_ITERATIONS": 6,
+        "TSPERF_JOB_LOCATION": "internal"
+    },
+    "tsc_node_18_15_0_material_ui": {
+        "TSPERF_JOB_KIND": "tsc",
+        "TSPERF_JOB_NAME": "tsc_node_18_15_0_material_ui",
+        "TSPERF_JOB_HOST": "node@18.15.0",
+        "TSPERF_JOB_SCENARIO": "material-ui",
+        "TSPERF_JOB_ITERATIONS": 6,
+        "TSPERF_JOB_LOCATION": "internal"
+    },
+    "tsc_node_18_15_0_Compiler_Unions": {
+        "TSPERF_JOB_KIND": "tsc",
+        "TSPERF_JOB_NAME": "tsc_node_18_15_0_Compiler_Unions",
+        "TSPERF_JOB_HOST": "node@18.15.0",
+        "TSPERF_JOB_SCENARIO": "Compiler-Unions",
+        "TSPERF_JOB_ITERATIONS": 6,
+        "TSPERF_JOB_LOCATION": "internal"
+    },
+    "tsc_node_18_15_0_xstate": {
+        "TSPERF_JOB_KIND": "tsc",
+        "TSPERF_JOB_NAME": "tsc_node_18_15_0_xstate",
+        "TSPERF_JOB_HOST": "node@18.15.0",
+        "TSPERF_JOB_SCENARIO": "xstate",
+        "TSPERF_JOB_ITERATIONS": 6,
+        "TSPERF_JOB_LOCATION": "internal"
+    },
+    "tsserver_node_18_15_0_Compiler_UnionsTSServer": {
+        "TSPERF_JOB_KIND": "tsserver",
+        "TSPERF_JOB_NAME": "tsserver_node_18_15_0_Compiler_UnionsTSServer",
+        "TSPERF_JOB_HOST": "node@18.15.0",
+        "TSPERF_JOB_SCENARIO": "Compiler-UnionsTSServer",
+        "TSPERF_JOB_ITERATIONS": 6,
+        "TSPERF_JOB_LOCATION": "internal"
+    },
+    "tsserver_node_18_15_0_CompilerTSServer": {
+        "TSPERF_JOB_KIND": "tsserver",
+        "TSPERF_JOB_NAME": "tsserver_node_18_15_0_CompilerTSServer",
+        "TSPERF_JOB_HOST": "node@18.15.0",
+        "TSPERF_JOB_SCENARIO": "CompilerTSServer",
+        "TSPERF_JOB_ITERATIONS": 6,
+        "TSPERF_JOB_LOCATION": "internal"
+    },
+    "tsserver_node_18_15_0_xstateTSServer": {
+        "TSPERF_JOB_KIND": "tsserver",
+        "TSPERF_JOB_NAME": "tsserver_node_18_15_0_xstateTSServer",
+        "TSPERF_JOB_HOST": "node@18.15.0",
+        "TSPERF_JOB_SCENARIO": "xstateTSServer",
+        "TSPERF_JOB_ITERATIONS": 6,
+        "TSPERF_JOB_LOCATION": "internal"
+    },
+    "startup_node_18_15_0_tsc_startup": {
+        "TSPERF_JOB_KIND": "startup",
+        "TSPERF_JOB_NAME": "startup_node_18_15_0_tsc_startup",
+        "TSPERF_JOB_HOST": "node@18.15.0",
+        "TSPERF_JOB_SCENARIO": "tsc-startup",
+        "TSPERF_JOB_ITERATIONS": 6,
+        "TSPERF_JOB_LOCATION": "internal"
+    },
+    "startup_node_18_15_0_tsserver_startup": {
+        "TSPERF_JOB_KIND": "startup",
+        "TSPERF_JOB_NAME": "startup_node_18_15_0_tsserver_startup",
+        "TSPERF_JOB_HOST": "node@18.15.0",
+        "TSPERF_JOB_SCENARIO": "tsserver-startup",
+        "TSPERF_JOB_ITERATIONS": 6,
+        "TSPERF_JOB_LOCATION": "internal"
+    },
+    "startup_node_18_15_0_tsserverlibrary_startup": {
+        "TSPERF_JOB_KIND": "startup",
+        "TSPERF_JOB_NAME": "startup_node_18_15_0_tsserverlibrary_startup",
+        "TSPERF_JOB_HOST": "node@18.15.0",
+        "TSPERF_JOB_SCENARIO": "tsserverlibrary-startup",
+        "TSPERF_JOB_ITERATIONS": 6,
+        "TSPERF_JOB_LOCATION": "internal"
+    },
+    "startup_node_18_15_0_typescript_startup": {
+        "TSPERF_JOB_KIND": "startup",
+        "TSPERF_JOB_NAME": "startup_node_18_15_0_typescript_startup",
+        "TSPERF_JOB_HOST": "node@18.15.0",
+        "TSPERF_JOB_SCENARIO": "typescript-startup",
+        "TSPERF_JOB_ITERATIONS": 6,
+        "TSPERF_JOB_LOCATION": "internal"
+    }
+}
+setting output MATRIX_ts_perf1={}
+##vso[task.setvariable variable=MATRIX_ts_perf1;isOutput=true]{}
+{}
+setting output MATRIX_ts_perf2={}
+##vso[task.setvariable variable=MATRIX_ts_perf2;isOutput=true]{}
+{}
+setting output MATRIX_ts_perf3={}
+##vso[task.setvariable variable=MATRIX_ts_perf3;isOutput=true]{}
+{}
+setting output MATRIX_ts_perf4={}
+##vso[task.setvariable variable=MATRIX_ts_perf4;isOutput=true]{}
+{}
+setting output TSPERF_PROCESS_KINDS=tsc tsserver startup
+##vso[task.setvariable variable=TSPERF_PROCESS_KINDS;isOutput=true]tsc tsserver startup
+setting output TSPERF_PROCESS_LOCATIONS=internal
+##vso[task.setvariable variable=TSPERF_PROCESS_LOCATIONS;isOutput=true]internal"
+`;
+
+exports[`generateMatrix { preset: 'regular', env: {} } 2`] = `""`;
+
+exports[`generateMatrix { preset: 'regular', env: {} } 3`] = `0`;
+
+exports[`generateMatrix { preset: 'tsc-only', env: {} } 1`] = `
+"setting output MATRIX_any={"tsc_node_18_15_0_Angular":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_node_18_15_0_Angular","TSPERF_JOB_HOST":"node@18.15.0","TSPERF_JOB_SCENARIO":"Angular","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"tsc_node_18_15_0_Monaco":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_node_18_15_0_Monaco","TSPERF_JOB_HOST":"node@18.15.0","TSPERF_JOB_SCENARIO":"Monaco","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"tsc_node_18_15_0_TFS":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_node_18_15_0_TFS","TSPERF_JOB_HOST":"node@18.15.0","TSPERF_JOB_SCENARIO":"TFS","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"tsc_node_18_15_0_material_ui":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_node_18_15_0_material_ui","TSPERF_JOB_HOST":"node@18.15.0","TSPERF_JOB_SCENARIO":"material-ui","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"tsc_node_18_15_0_Compiler_Unions":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_node_18_15_0_Compiler_Unions","TSPERF_JOB_HOST":"node@18.15.0","TSPERF_JOB_SCENARIO":"Compiler-Unions","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"tsc_node_18_15_0_xstate":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_node_18_15_0_xstate","TSPERF_JOB_HOST":"node@18.15.0","TSPERF_JOB_SCENARIO":"xstate","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"}}
+##vso[task.setvariable variable=MATRIX_any;isOutput=true]{"tsc_node_18_15_0_Angular":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_node_18_15_0_Angular","TSPERF_JOB_HOST":"node@18.15.0","TSPERF_JOB_SCENARIO":"Angular","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"tsc_node_18_15_0_Monaco":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_node_18_15_0_Monaco","TSPERF_JOB_HOST":"node@18.15.0","TSPERF_JOB_SCENARIO":"Monaco","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"tsc_node_18_15_0_TFS":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_node_18_15_0_TFS","TSPERF_JOB_HOST":"node@18.15.0","TSPERF_JOB_SCENARIO":"TFS","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"tsc_node_18_15_0_material_ui":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_node_18_15_0_material_ui","TSPERF_JOB_HOST":"node@18.15.0","TSPERF_JOB_SCENARIO":"material-ui","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"tsc_node_18_15_0_Compiler_Unions":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_node_18_15_0_Compiler_Unions","TSPERF_JOB_HOST":"node@18.15.0","TSPERF_JOB_SCENARIO":"Compiler-Unions","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"tsc_node_18_15_0_xstate":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_node_18_15_0_xstate","TSPERF_JOB_HOST":"node@18.15.0","TSPERF_JOB_SCENARIO":"xstate","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"}}
+{
+    "tsc_node_18_15_0_Angular": {
+        "TSPERF_JOB_KIND": "tsc",
+        "TSPERF_JOB_NAME": "tsc_node_18_15_0_Angular",
+        "TSPERF_JOB_HOST": "node@18.15.0",
+        "TSPERF_JOB_SCENARIO": "Angular",
+        "TSPERF_JOB_ITERATIONS": 6,
+        "TSPERF_JOB_LOCATION": "internal"
+    },
+    "tsc_node_18_15_0_Monaco": {
+        "TSPERF_JOB_KIND": "tsc",
+        "TSPERF_JOB_NAME": "tsc_node_18_15_0_Monaco",
+        "TSPERF_JOB_HOST": "node@18.15.0",
+        "TSPERF_JOB_SCENARIO": "Monaco",
+        "TSPERF_JOB_ITERATIONS": 6,
+        "TSPERF_JOB_LOCATION": "internal"
+    },
+    "tsc_node_18_15_0_TFS": {
+        "TSPERF_JOB_KIND": "tsc",
+        "TSPERF_JOB_NAME": "tsc_node_18_15_0_TFS",
+        "TSPERF_JOB_HOST": "node@18.15.0",
+        "TSPERF_JOB_SCENARIO": "TFS",
+        "TSPERF_JOB_ITERATIONS": 6,
+        "TSPERF_JOB_LOCATION": "internal"
+    },
+    "tsc_node_18_15_0_material_ui": {
+        "TSPERF_JOB_KIND": "tsc",
+        "TSPERF_JOB_NAME": "tsc_node_18_15_0_material_ui",
+        "TSPERF_JOB_HOST": "node@18.15.0",
+        "TSPERF_JOB_SCENARIO": "material-ui",
+        "TSPERF_JOB_ITERATIONS": 6,
+        "TSPERF_JOB_LOCATION": "internal"
+    },
+    "tsc_node_18_15_0_Compiler_Unions": {
+        "TSPERF_JOB_KIND": "tsc",
+        "TSPERF_JOB_NAME": "tsc_node_18_15_0_Compiler_Unions",
+        "TSPERF_JOB_HOST": "node@18.15.0",
+        "TSPERF_JOB_SCENARIO": "Compiler-Unions",
+        "TSPERF_JOB_ITERATIONS": 6,
+        "TSPERF_JOB_LOCATION": "internal"
+    },
+    "tsc_node_18_15_0_xstate": {
+        "TSPERF_JOB_KIND": "tsc",
+        "TSPERF_JOB_NAME": "tsc_node_18_15_0_xstate",
+        "TSPERF_JOB_HOST": "node@18.15.0",
+        "TSPERF_JOB_SCENARIO": "xstate",
+        "TSPERF_JOB_ITERATIONS": 6,
+        "TSPERF_JOB_LOCATION": "internal"
+    }
+}
+setting output MATRIX_ts_perf1={}
+##vso[task.setvariable variable=MATRIX_ts_perf1;isOutput=true]{}
+{}
+setting output MATRIX_ts_perf2={}
+##vso[task.setvariable variable=MATRIX_ts_perf2;isOutput=true]{}
+{}
+setting output MATRIX_ts_perf3={}
+##vso[task.setvariable variable=MATRIX_ts_perf3;isOutput=true]{}
+{}
+setting output MATRIX_ts_perf4={}
+##vso[task.setvariable variable=MATRIX_ts_perf4;isOutput=true]{}
+{}
+setting output TSPERF_PROCESS_KINDS=tsc
+##vso[task.setvariable variable=TSPERF_PROCESS_KINDS;isOutput=true]tsc
+setting output TSPERF_PROCESS_LOCATIONS=internal
+##vso[task.setvariable variable=TSPERF_PROCESS_LOCATIONS;isOutput=true]internal"
+`;
+
+exports[`generateMatrix { preset: 'tsc-only', env: {} } 2`] = `""`;
+
+exports[`generateMatrix { preset: 'tsc-only', env: {} } 3`] = `0`;
+
+exports[`generateMatrix { preset: 'vscode', env: {} } 1`] = `
+"setting output MATRIX_any={"tsc_vscode_1_82_1_Angular":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_vscode_1_82_1_Angular","TSPERF_JOB_HOST":"vscode@1.82.1","TSPERF_JOB_SCENARIO":"Angular","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"tsc_vscode_1_82_1_Monaco":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_vscode_1_82_1_Monaco","TSPERF_JOB_HOST":"vscode@1.82.1","TSPERF_JOB_SCENARIO":"Monaco","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"tsc_vscode_1_82_1_TFS":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_vscode_1_82_1_TFS","TSPERF_JOB_HOST":"vscode@1.82.1","TSPERF_JOB_SCENARIO":"TFS","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"tsc_vscode_1_82_1_material_ui":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_vscode_1_82_1_material_ui","TSPERF_JOB_HOST":"vscode@1.82.1","TSPERF_JOB_SCENARIO":"material-ui","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"tsc_vscode_1_82_1_Compiler_Unions":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_vscode_1_82_1_Compiler_Unions","TSPERF_JOB_HOST":"vscode@1.82.1","TSPERF_JOB_SCENARIO":"Compiler-Unions","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"tsc_vscode_1_82_1_xstate":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_vscode_1_82_1_xstate","TSPERF_JOB_HOST":"vscode@1.82.1","TSPERF_JOB_SCENARIO":"xstate","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"tsserver_vscode_1_82_1_Compiler_UnionsTSServer":{"TSPERF_JOB_KIND":"tsserver","TSPERF_JOB_NAME":"tsserver_vscode_1_82_1_Compiler_UnionsTSServer","TSPERF_JOB_HOST":"vscode@1.82.1","TSPERF_JOB_SCENARIO":"Compiler-UnionsTSServer","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"tsserver_vscode_1_82_1_CompilerTSServer":{"TSPERF_JOB_KIND":"tsserver","TSPERF_JOB_NAME":"tsserver_vscode_1_82_1_CompilerTSServer","TSPERF_JOB_HOST":"vscode@1.82.1","TSPERF_JOB_SCENARIO":"CompilerTSServer","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"tsserver_vscode_1_82_1_xstateTSServer":{"TSPERF_JOB_KIND":"tsserver","TSPERF_JOB_NAME":"tsserver_vscode_1_82_1_xstateTSServer","TSPERF_JOB_HOST":"vscode@1.82.1","TSPERF_JOB_SCENARIO":"xstateTSServer","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"startup_vscode_1_82_1_tsc_startup":{"TSPERF_JOB_KIND":"startup","TSPERF_JOB_NAME":"startup_vscode_1_82_1_tsc_startup","TSPERF_JOB_HOST":"vscode@1.82.1","TSPERF_JOB_SCENARIO":"tsc-startup","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"startup_vscode_1_82_1_tsserver_startup":{"TSPERF_JOB_KIND":"startup","TSPERF_JOB_NAME":"startup_vscode_1_82_1_tsserver_startup","TSPERF_JOB_HOST":"vscode@1.82.1","TSPERF_JOB_SCENARIO":"tsserver-startup","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"startup_vscode_1_82_1_tsserverlibrary_startup":{"TSPERF_JOB_KIND":"startup","TSPERF_JOB_NAME":"startup_vscode_1_82_1_tsserverlibrary_startup","TSPERF_JOB_HOST":"vscode@1.82.1","TSPERF_JOB_SCENARIO":"tsserverlibrary-startup","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"startup_vscode_1_82_1_typescript_startup":{"TSPERF_JOB_KIND":"startup","TSPERF_JOB_NAME":"startup_vscode_1_82_1_typescript_startup","TSPERF_JOB_HOST":"vscode@1.82.1","TSPERF_JOB_SCENARIO":"typescript-startup","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"}}
+##vso[task.setvariable variable=MATRIX_any;isOutput=true]{"tsc_vscode_1_82_1_Angular":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_vscode_1_82_1_Angular","TSPERF_JOB_HOST":"vscode@1.82.1","TSPERF_JOB_SCENARIO":"Angular","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"tsc_vscode_1_82_1_Monaco":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_vscode_1_82_1_Monaco","TSPERF_JOB_HOST":"vscode@1.82.1","TSPERF_JOB_SCENARIO":"Monaco","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"tsc_vscode_1_82_1_TFS":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_vscode_1_82_1_TFS","TSPERF_JOB_HOST":"vscode@1.82.1","TSPERF_JOB_SCENARIO":"TFS","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"tsc_vscode_1_82_1_material_ui":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_vscode_1_82_1_material_ui","TSPERF_JOB_HOST":"vscode@1.82.1","TSPERF_JOB_SCENARIO":"material-ui","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"tsc_vscode_1_82_1_Compiler_Unions":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_vscode_1_82_1_Compiler_Unions","TSPERF_JOB_HOST":"vscode@1.82.1","TSPERF_JOB_SCENARIO":"Compiler-Unions","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"tsc_vscode_1_82_1_xstate":{"TSPERF_JOB_KIND":"tsc","TSPERF_JOB_NAME":"tsc_vscode_1_82_1_xstate","TSPERF_JOB_HOST":"vscode@1.82.1","TSPERF_JOB_SCENARIO":"xstate","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"tsserver_vscode_1_82_1_Compiler_UnionsTSServer":{"TSPERF_JOB_KIND":"tsserver","TSPERF_JOB_NAME":"tsserver_vscode_1_82_1_Compiler_UnionsTSServer","TSPERF_JOB_HOST":"vscode@1.82.1","TSPERF_JOB_SCENARIO":"Compiler-UnionsTSServer","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"tsserver_vscode_1_82_1_CompilerTSServer":{"TSPERF_JOB_KIND":"tsserver","TSPERF_JOB_NAME":"tsserver_vscode_1_82_1_CompilerTSServer","TSPERF_JOB_HOST":"vscode@1.82.1","TSPERF_JOB_SCENARIO":"CompilerTSServer","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"tsserver_vscode_1_82_1_xstateTSServer":{"TSPERF_JOB_KIND":"tsserver","TSPERF_JOB_NAME":"tsserver_vscode_1_82_1_xstateTSServer","TSPERF_JOB_HOST":"vscode@1.82.1","TSPERF_JOB_SCENARIO":"xstateTSServer","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"startup_vscode_1_82_1_tsc_startup":{"TSPERF_JOB_KIND":"startup","TSPERF_JOB_NAME":"startup_vscode_1_82_1_tsc_startup","TSPERF_JOB_HOST":"vscode@1.82.1","TSPERF_JOB_SCENARIO":"tsc-startup","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"startup_vscode_1_82_1_tsserver_startup":{"TSPERF_JOB_KIND":"startup","TSPERF_JOB_NAME":"startup_vscode_1_82_1_tsserver_startup","TSPERF_JOB_HOST":"vscode@1.82.1","TSPERF_JOB_SCENARIO":"tsserver-startup","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"startup_vscode_1_82_1_tsserverlibrary_startup":{"TSPERF_JOB_KIND":"startup","TSPERF_JOB_NAME":"startup_vscode_1_82_1_tsserverlibrary_startup","TSPERF_JOB_HOST":"vscode@1.82.1","TSPERF_JOB_SCENARIO":"tsserverlibrary-startup","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"},"startup_vscode_1_82_1_typescript_startup":{"TSPERF_JOB_KIND":"startup","TSPERF_JOB_NAME":"startup_vscode_1_82_1_typescript_startup","TSPERF_JOB_HOST":"vscode@1.82.1","TSPERF_JOB_SCENARIO":"typescript-startup","TSPERF_JOB_ITERATIONS":6,"TSPERF_JOB_LOCATION":"internal"}}
+{
+    "tsc_vscode_1_82_1_Angular": {
+        "TSPERF_JOB_KIND": "tsc",
+        "TSPERF_JOB_NAME": "tsc_vscode_1_82_1_Angular",
+        "TSPERF_JOB_HOST": "vscode@1.82.1",
+        "TSPERF_JOB_SCENARIO": "Angular",
+        "TSPERF_JOB_ITERATIONS": 6,
+        "TSPERF_JOB_LOCATION": "internal"
+    },
+    "tsc_vscode_1_82_1_Monaco": {
+        "TSPERF_JOB_KIND": "tsc",
+        "TSPERF_JOB_NAME": "tsc_vscode_1_82_1_Monaco",
+        "TSPERF_JOB_HOST": "vscode@1.82.1",
+        "TSPERF_JOB_SCENARIO": "Monaco",
+        "TSPERF_JOB_ITERATIONS": 6,
+        "TSPERF_JOB_LOCATION": "internal"
+    },
+    "tsc_vscode_1_82_1_TFS": {
+        "TSPERF_JOB_KIND": "tsc",
+        "TSPERF_JOB_NAME": "tsc_vscode_1_82_1_TFS",
+        "TSPERF_JOB_HOST": "vscode@1.82.1",
+        "TSPERF_JOB_SCENARIO": "TFS",
+        "TSPERF_JOB_ITERATIONS": 6,
+        "TSPERF_JOB_LOCATION": "internal"
+    },
+    "tsc_vscode_1_82_1_material_ui": {
+        "TSPERF_JOB_KIND": "tsc",
+        "TSPERF_JOB_NAME": "tsc_vscode_1_82_1_material_ui",
+        "TSPERF_JOB_HOST": "vscode@1.82.1",
+        "TSPERF_JOB_SCENARIO": "material-ui",
+        "TSPERF_JOB_ITERATIONS": 6,
+        "TSPERF_JOB_LOCATION": "internal"
+    },
+    "tsc_vscode_1_82_1_Compiler_Unions": {
+        "TSPERF_JOB_KIND": "tsc",
+        "TSPERF_JOB_NAME": "tsc_vscode_1_82_1_Compiler_Unions",
+        "TSPERF_JOB_HOST": "vscode@1.82.1",
+        "TSPERF_JOB_SCENARIO": "Compiler-Unions",
+        "TSPERF_JOB_ITERATIONS": 6,
+        "TSPERF_JOB_LOCATION": "internal"
+    },
+    "tsc_vscode_1_82_1_xstate": {
+        "TSPERF_JOB_KIND": "tsc",
+        "TSPERF_JOB_NAME": "tsc_vscode_1_82_1_xstate",
+        "TSPERF_JOB_HOST": "vscode@1.82.1",
+        "TSPERF_JOB_SCENARIO": "xstate",
+        "TSPERF_JOB_ITERATIONS": 6,
+        "TSPERF_JOB_LOCATION": "internal"
+    },
+    "tsserver_vscode_1_82_1_Compiler_UnionsTSServer": {
+        "TSPERF_JOB_KIND": "tsserver",
+        "TSPERF_JOB_NAME": "tsserver_vscode_1_82_1_Compiler_UnionsTSServer",
+        "TSPERF_JOB_HOST": "vscode@1.82.1",
+        "TSPERF_JOB_SCENARIO": "Compiler-UnionsTSServer",
+        "TSPERF_JOB_ITERATIONS": 6,
+        "TSPERF_JOB_LOCATION": "internal"
+    },
+    "tsserver_vscode_1_82_1_CompilerTSServer": {
+        "TSPERF_JOB_KIND": "tsserver",
+        "TSPERF_JOB_NAME": "tsserver_vscode_1_82_1_CompilerTSServer",
+        "TSPERF_JOB_HOST": "vscode@1.82.1",
+        "TSPERF_JOB_SCENARIO": "CompilerTSServer",
+        "TSPERF_JOB_ITERATIONS": 6,
+        "TSPERF_JOB_LOCATION": "internal"
+    },
+    "tsserver_vscode_1_82_1_xstateTSServer": {
+        "TSPERF_JOB_KIND": "tsserver",
+        "TSPERF_JOB_NAME": "tsserver_vscode_1_82_1_xstateTSServer",
+        "TSPERF_JOB_HOST": "vscode@1.82.1",
+        "TSPERF_JOB_SCENARIO": "xstateTSServer",
+        "TSPERF_JOB_ITERATIONS": 6,
+        "TSPERF_JOB_LOCATION": "internal"
+    },
+    "startup_vscode_1_82_1_tsc_startup": {
+        "TSPERF_JOB_KIND": "startup",
+        "TSPERF_JOB_NAME": "startup_vscode_1_82_1_tsc_startup",
+        "TSPERF_JOB_HOST": "vscode@1.82.1",
+        "TSPERF_JOB_SCENARIO": "tsc-startup",
+        "TSPERF_JOB_ITERATIONS": 6,
+        "TSPERF_JOB_LOCATION": "internal"
+    },
+    "startup_vscode_1_82_1_tsserver_startup": {
+        "TSPERF_JOB_KIND": "startup",
+        "TSPERF_JOB_NAME": "startup_vscode_1_82_1_tsserver_startup",
+        "TSPERF_JOB_HOST": "vscode@1.82.1",
+        "TSPERF_JOB_SCENARIO": "tsserver-startup",
+        "TSPERF_JOB_ITERATIONS": 6,
+        "TSPERF_JOB_LOCATION": "internal"
+    },
+    "startup_vscode_1_82_1_tsserverlibrary_startup": {
+        "TSPERF_JOB_KIND": "startup",
+        "TSPERF_JOB_NAME": "startup_vscode_1_82_1_tsserverlibrary_startup",
+        "TSPERF_JOB_HOST": "vscode@1.82.1",
+        "TSPERF_JOB_SCENARIO": "tsserverlibrary-startup",
+        "TSPERF_JOB_ITERATIONS": 6,
+        "TSPERF_JOB_LOCATION": "internal"
+    },
+    "startup_vscode_1_82_1_typescript_startup": {
+        "TSPERF_JOB_KIND": "startup",
+        "TSPERF_JOB_NAME": "startup_vscode_1_82_1_typescript_startup",
+        "TSPERF_JOB_HOST": "vscode@1.82.1",
+        "TSPERF_JOB_SCENARIO": "typescript-startup",
+        "TSPERF_JOB_ITERATIONS": 6,
+        "TSPERF_JOB_LOCATION": "internal"
+    }
+}
+setting output MATRIX_ts_perf1={}
+##vso[task.setvariable variable=MATRIX_ts_perf1;isOutput=true]{}
+{}
+setting output MATRIX_ts_perf2={}
+##vso[task.setvariable variable=MATRIX_ts_perf2;isOutput=true]{}
+{}
+setting output MATRIX_ts_perf3={}
+##vso[task.setvariable variable=MATRIX_ts_perf3;isOutput=true]{}
+{}
+setting output MATRIX_ts_perf4={}
+##vso[task.setvariable variable=MATRIX_ts_perf4;isOutput=true]{}
+{}
+setting output TSPERF_PROCESS_KINDS=tsc tsserver startup
+##vso[task.setvariable variable=TSPERF_PROCESS_KINDS;isOutput=true]tsc tsserver startup
+setting output TSPERF_PROCESS_LOCATIONS=internal
+##vso[task.setvariable variable=TSPERF_PROCESS_LOCATIONS;isOutput=true]internal"
+`;
+
+exports[`generateMatrix { preset: 'vscode', env: {} } 2`] = `""`;
+
+exports[`generateMatrix { preset: 'vscode', env: {} } 3`] = `0`;

--- a/scripts/src/__tests__/generateMatrix.test.ts
+++ b/scripts/src/__tests__/generateMatrix.test.ts
@@ -1,0 +1,37 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import util from "node:util";
+
+import { execa } from "execa";
+import { test } from "vitest";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const tests = [
+    { preset: "full", env: {} },
+    { preset: "full", env: { USE_BASELINE_MACHINE: "true" } },
+    { preset: "regular", env: {} },
+    { preset: "tsc-only", env: {} },
+    { preset: "bun", env: {} },
+    { preset: "vscode", env: {} },
+    { preset: "public", env: {} },
+];
+
+// https://github.com/vitest-dev/vitest/issues/4963
+// https://github.com/vitest-dev/vitest/issues/4642
+for (const t of tests) {
+    test.concurrent(`generateMatrix ${util.inspect(t)}`, async ({ expect }) => {
+        const result = await execa(
+            "tsx",
+            [path.join(__dirname, "../generateMatrix.ts"), "--preset", t.preset],
+            {
+                env: t.env,
+                reject: false,
+            },
+        );
+        expect(result.stdout, "stdout").toMatchSnapshot();
+        expect(result.stderr, "stderr").toMatchSnapshot();
+        expect(result.exitCode, "exitCode").toMatchSnapshot();
+    });
+}

--- a/vitest.workspace.mjs
+++ b/vitest.workspace.mjs
@@ -1,0 +1,7 @@
+import { defineWorkspace } from "vitest/config";
+
+export default defineWorkspace([
+    "scripts",
+    // "ts-perf",
+    // "ts-perf/packages/*",
+]);


### PR DESCRIPTION
This adds `vitest`, snapshotting the output of the `generateMatrix.ts` script (which will shortly change).