### PR TITLE
Fix bad copilot change that made processLocations space separated

### DIFF
--- a/scripts/src/generateMatrix.ts
+++ b/scripts/src/generateMatrix.ts
@@ -250,7 +250,8 @@ export function generateMatrix(presetArg: string, baselining: boolean, log?: boo
     // produced previously and need to be processed. This is a space separated list,
     // iterated in the pipeline in bash.
     outputVariables[`TSPERF_PROCESS_KINDS`] = kindOrder.filter(kind => processKinds.has(kind)).join(" ");
-    outputVariables[`TSPERF_PROCESS_LOCATIONS`] = [...processLocations].sort().join(" ");
+    // Comma separated, parsed by runTsPerf.ts.
+    outputVariables[`TSPERF_PROCESS_LOCATIONS`] = [...processLocations].sort().join(",");
 
     return { matrix, outputVariables };
 }


### PR DESCRIPTION
No test change; thankfully this didn't break anything as no preset has both internal and public benchmarks.