### PR TITLE
Fix bad readme link in ts-perf submonorepo

### DIFF
--- a/ts-perf/README.md
+++ b/ts-perf/README.md
@@ -2,4 +2,4 @@
 
 `ts-perf` is a suite of performance testing tools designed for analyzing and benchmarking performance for the TypeScript compiler.
 
-See [packages/cli/README.md](ts-perf/packages/cli/README.md) for more info.
+See [packages/cli/README.md](packages/cli/README.md) for more info.


### PR DESCRIPTION
Apparently this is just plain relative, not absolute. Oops.