### PR TITLE
Fix blob names

### DIFF
--- a/build/benchmark.yml
+++ b/build/benchmark.yml
@@ -391,10 +391,21 @@ jobs:
           set -eo pipefail
           for KIND in $(TSPERF_PROCESS_KINDS); do
             echo "Uploading ${KIND} benchmarks"
+            case ${KIND} in 
+              tsc)
+                NAME="linux"
+                ;;
+              tsserver)
+                NAME="linux.server"
+                ;;
+              *)
+                NAME="linux.${KIND}"
+                ;;
+            esac
             node $(BENCH_SCRIPTS)/runTsPerf.js benchmark-${KIND} \
               --builtDir $(BUILT_TYPESCRIPT_DIR)/baseline \
               --load $(MERGED_DIR)/baseline.${KIND}.benchmark \
-              --saveBlob linux
+              --saveBlob ${NAME}
           done
         displayName: Upload benchmarks to blob store
         condition: and(succeeded(), eq(variables['SHOULD_UPLOAD'], 'true'))


### PR DESCRIPTION
In https://github.com/microsoft/typescript-benchmarking/commit/a17a6311441ce10e793a88f50139429ecdfe97c1#diff-d78d2f7d7dc72bda4fe14e23fa110957d76c8375de66249a8acca29175f11c83R349 I screwed up the blob names, causing all benchmarks to upload to the same blob names. This meant that we basically lost all historical data since this commit.

This code should be moved into the ts-perf wrapper script since it's clear that it's error prone, but the other filename based code is still in the pipeline so I'll make that change later and just fix this now.