### PR TITLE
In each benchmark job, print a comparison

### DIFF
--- a/build/benchmark.yml
+++ b/build/benchmark.yml
@@ -265,6 +265,15 @@ jobs:
                 --save $(ARTIFACTS_DIR)/baseline_$(TSPERF_JOB_NAME).$(TSPERF_JOB_KIND).benchmark
             displayName: Run baseline $(TSPERF_JOB_KIND) benchmark
 
+          - bash: |
+              set -eo pipefail
+              node $(BENCH_SCRIPTS)/runTsPerf.js benchmark-$(TSPERF_JOB_KIND) \
+                --builtDir $(BUILT_TYPESCRIPT_DIR)/baseline \
+                --baseline $(ARTIFACTS_DIR)/baseline_$(TSPERF_JOB_NAME).$(TSPERF_JOB_KIND).benchmark \
+                --load $(ARTIFACTS_DIR)/pr_$(TSPERF_JOB_NAME).$(TSPERF_JOB_KIND).benchmark
+            displayName: Compare PR to baseline benchmark
+            condition: and(succeeded(), eq(variables['IS_PR'], 'true'))
+
           - publish: $(ARTIFACTS_DIR)
             artifact: PartialBenchmark_$(TSPERF_JOB_NAME)
             displayName: Publish benchmarks


### PR DESCRIPTION
I often go into the logs to get a preview before the full run is done; it's be nice to just print the comparison as early as possible.