### PR TITLE
Scenario cleanup, make --scenarioDir singular

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -91,6 +91,12 @@ importers:
       '@azure/storage-blob':
         specifier: ^12.17.0
         version: 12.17.0
+      '@esfx/collections-hashmap':
+        specifier: ^1.0.2
+        version: 1.0.2
+      '@esfx/collections-hashset':
+        specifier: ^1.0.2
+        version: 1.0.2
       '@esfx/equatable':
         specifier: ^1.0.2
         version: 1.0.2

--- a/ts-perf/packages/api/package.json
+++ b/ts-perf/packages/api/package.json
@@ -26,6 +26,8 @@
         "@azure/identity": "^4.1.0",
         "@azure/storage-blob": "^12.17.0",
         "@esfx/equatable": "^1.0.2",
+        "@esfx/collections-hashset": "^1.0.2",
+        "@esfx/collections-hashmap": "^1.0.2",
         "@stdlib/stats-base-dists-normal-cdf": "^0.2.1",
         "@ts-perf/core": "workspace:^",
         "chalk": "^4.1.2",

--- a/ts-perf/packages/api/src/options.ts
+++ b/ts-perf/packages/api/src/options.ts
@@ -5,7 +5,7 @@ import { localSuiteDirectory } from "@ts-perf/core";
 import { CommandLineOption, CommandLineOptionSet, CommandLineOptionSets, CommandLineParseError } from "power-options";
 
 export interface CommonOptions {
-    scenarioDirs?: string[];
+    scenarioDir?: string;
 }
 
 export interface CompilerOptions extends CommonOptions {
@@ -43,21 +43,17 @@ const suiteDir: CommandLineOption = {
         "Use <directory> as the root location for test suites (i.e. './cases/solutions'). If not set, uses TSPERF_SUITE_DIR environment variable, if found. Otherwise, uses '~/.tsperf/solutions', if present.",
 };
 
-const scenarioDirs: CommandLineOption = {
+const scenarioDir: CommandLineOption = {
     type: "string",
     longName: "scenarioDir",
     alias: ["scenarioDirs", "scenarioConfigDir", "scenarioConfigDirs"],
-    multiple: true,
     validate: validatePath,
     defaultValue() {
-        const dirs = process.env.TSPERF_SCENARIO_DIRS?.split(path.delimiter)
-            .map(dirname => findPath(dirname, /*relative*/ undefined, /*walkUpParents*/ false))
-            .filter((dirname): dirname is string => !!dirname);
-        return dirs;
+        return findPath(process.env.TSPERF_SCENARIO_DIR, /*relative*/ undefined, /*walkUpParents*/ false);
     },
     param: "directory",
     description:
-        "Use <directory> as a location containing individual test scenario folders each with a 'scenario.json'. If not set, uses TSPERF_SCENARIO_DIRS environment variable, if found. '~/.tsperf/solutions' will always be included, if present.",
+        "Use <directory> as a location containing individual test scenario folders each with a 'scenario.json'. If not set, uses TSPERF_SCENARIO_DIR environment variable, if found. '~/.tsperf/solutions' will always be included, if present.",
 };
 
 const builtDir: CommandLineOption = {
@@ -82,7 +78,7 @@ const builtDir: CommandLineOption = {
 const common: CommandLineOptionSet = {
     merge: true,
     options: {
-        scenarioDirs,
+        scenarioDir,
     },
 };
 

--- a/ts-perf/packages/commands/src/benchmark/measure.ts
+++ b/ts-perf/packages/commands/src/benchmark/measure.ts
@@ -64,7 +64,7 @@ export async function measureAndRunScenarios({ kind, options }: TSOptions, host:
         options.repositoryDate,
         options.repositoryCommitSubject,
     );
-    const scenarios = await Scenario.findScenarios(options.scenarioDirs, options.scenarios, kind);
+    const scenarios = await Scenario.findScenarios(options.scenarios, { scenarioDir: options.scenarioDir, kind });
     if (scenarios.length === 0) {
         host.error(
             `abort: Could not find any scenario of kind '${kind}' ${

--- a/ts-perf/packages/commands/src/heap/index.ts
+++ b/ts-perf/packages/commands/src/heap/index.ts
@@ -25,7 +25,7 @@ export interface HeapProfilerOptions extends CompilerOptions {
 
 export async function heap(options: HeapProfilerOptions, host: HostContext) {
     const tempDirs = await getTempDirectories();
-    const scenario = await Scenario.findScenario(options.scenarioDirs, options.scenario, /*kind*/ "tsc");
+    const scenario = await Scenario.findScenario(options.scenario, { scenarioDir: options.scenarioDir, kind: "tsc" });
     const testHost = options.host
         ? await Host.findHost(options.host, { onlyHosts: ["node"] })
         : Host.current;

--- a/ts-perf/packages/commands/src/profile/index.ts
+++ b/ts-perf/packages/commands/src/profile/index.ts
@@ -18,7 +18,7 @@ const profiler = require.resolve("@ts-perf/profiler/bin/ts-profiler");
 
 export async function profile(options: ProfilerOptions, host: HostContext) {
     const tempDirs = await getTempDirectories();
-    const scenario = await Scenario.findScenario(options.scenarioDirs, options.scenario, /*kind*/ "tsc");
+    const scenario = await Scenario.findScenario(options.scenario, { scenarioDir: options.scenarioDir, kind: "tsc" });
     const testHost = options.host
         ? await Host.findHost(options.host, { onlyHosts: ["node"] })
         : Host.current;

--- a/ts-perf/packages/commands/src/scenario/add.ts
+++ b/ts-perf/packages/commands/src/scenario/add.ts
@@ -1,11 +1,10 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 
-import { Command, CommandMap, Scenario } from "@ts-perf/api";
+import { Command, CommandMap, CommonOptions, Scenario } from "@ts-perf/api";
 import { HostContext, localScenariosDirectory } from "@ts-perf/core";
 
-export interface AddScenarioOptions {
-    scenarioDir?: string;
+export interface AddScenarioOptions extends CommonOptions {
     name: string;
     args?: string[];
     platforms?: string[];
@@ -14,8 +13,10 @@ export interface AddScenarioOptions {
 }
 
 export async function addScenario(options: AddScenarioOptions, context: HostContext) {
-    const scenariosDir = options.scenarioDir ? path.resolve(options.scenarioDir) : localScenariosDirectory;
-    const scenarioDir = path.resolve(scenariosDir, path.basename(options.name));
+    const scenarioDir = path.resolve(
+        options.scenarioDir ? options.scenarioDir : localScenariosDirectory,
+        path.basename(options.name),
+    );
     if (!fs.existsSync(scenarioDir)) {
         await fs.promises.mkdir(scenarioDir, { recursive: true });
     }
@@ -31,6 +32,7 @@ const command: Command<AddScenarioOptions> = {
     commandName: "add",
     summary: "Add a local compiler scenario.",
     description: "Add a local compiler scenario.",
+    include: ["common"],
     options: {
         name: {
             type: "string",
@@ -41,13 +43,6 @@ const command: Command<AddScenarioOptions> = {
             defaultValue: () => [],
             param: "name",
             description: "",
-        },
-        scenarioDir: {
-            type: "string",
-            alias: "scenarioConfigDir",
-            param: "directory",
-            description:
-                "Use <directory> as a location containing individual test scenario folders each with a 'scenario.json'. If not set, uses '~/.tsperf/scenarios', if present.",
         },
         args: {
             type: "string",

--- a/ts-perf/packages/commands/src/scenario/configure.ts
+++ b/ts-perf/packages/commands/src/scenario/configure.ts
@@ -10,7 +10,7 @@ export interface ConfigureScenarioOptions extends CommonOptions {
 }
 
 export async function configureScenario(options: ConfigureScenarioOptions, context: HostContext) {
-    const scenarios = await Scenario.findScenarios(options.scenarioDirs, options.scenarios);
+    const scenarios = await Scenario.findScenarios(options.scenarios, { scenarioDir: options.scenarioDir });
     if (scenarios.length === 0) {
         context.error(`No matching scenarios.`);
         return;

--- a/ts-perf/packages/commands/src/scenario/delete.ts
+++ b/ts-perf/packages/commands/src/scenario/delete.ts
@@ -10,7 +10,8 @@ export interface DeleteScenarioOptions extends CompilerOptions, CommonOptions {
 }
 
 export async function deleteScenario(options: DeleteScenarioOptions, context: HostContext) {
-    const scenarios = await Scenario.findScenarios(options.scenarioDirs, [options.scenario], /*kind*/ undefined, {
+    const scenarios = await Scenario.findScenarios([options.scenario], {
+        scenarioDir: options.scenarioDir,
         includeUnsupported: true,
     });
     if (scenarios.length === 0) {

--- a/ts-perf/packages/commands/src/scenario/list.ts
+++ b/ts-perf/packages/commands/src/scenario/list.ts
@@ -9,7 +9,7 @@ export interface ListScenarioOptions extends CommonOptions {
 }
 
 export async function listScenarios(options: ListScenarioOptions, context: HostContext) {
-    const scenarios = await Scenario.getAvailableScenarios(options.scenarioDirs);
+    const scenarios = await Scenario.getAvailableScenarios({ scenarioDir: options.scenarioDir });
     context.log(
         os.EOL + "Scenarios:" + os.EOL + new Table<Scenario>({
             useColor: options.color,

--- a/ts-perf/packages/commands/src/trace/index.ts
+++ b/ts-perf/packages/commands/src/trace/index.ts
@@ -25,7 +25,7 @@ export interface TraceOptions extends CompilerOptions, CommonOptions {
 }
 
 export async function trace(options: TraceOptions, host: HostContext) {
-    const scenario = await Scenario.findScenario(options.scenarioDirs, options.scenario, /*kind*/ "tsc");
+    const scenario = await Scenario.findScenario(options.scenario, { scenarioDir: options.scenarioDir, kind: "tsc" });
 
     if (!scenario) {
         host.error(`abort: Compiler scenario not found.`);

--- a/ts-perf/packages/core/src/index.ts
+++ b/ts-perf/packages/core/src/index.ts
@@ -1,3 +1,4 @@
+export * from "./pathComparer";
 export * from "./stringComparer";
 export * from "./sys";
 export * from "./types";

--- a/ts-perf/packages/core/src/pathComparer.ts
+++ b/ts-perf/packages/core/src/pathComparer.ts
@@ -1,0 +1,73 @@
+import * as os from "node:os";
+
+import { Comparer, Equaler } from "@esfx/equatable";
+
+import { StringComparer } from "./stringComparer";
+import { normalizeSlashes, removeWindowsLongPathPrefix, trimTrailingDirectorySeparator } from "./utils";
+
+export class PathComparer implements Comparer<string>, Equaler<string> {
+    public static readonly caseSensitive = new PathComparer(StringComparer.caseSensitiveNumeric);
+    public static readonly caseInsensitive = new PathComparer(StringComparer.caseInsensitiveNumeric);
+    public static readonly fileSystem = os.platform() === "win32" ? this.caseInsensitive : this.caseSensitive;
+
+    private _comparer: Comparer<string> & Equaler<string>;
+
+    constructor(comparerOrIgnoreCase?: boolean | Comparer<string> & Equaler<string>) {
+        this._comparer = typeof comparerOrIgnoreCase === "object" ? comparerOrIgnoreCase
+            : comparerOrIgnoreCase ? StringComparer.caseInsensitiveNumeric
+            : StringComparer.caseInsensitiveNumeric;
+    }
+
+    public compare(x: string, y: string): number;
+    public compare(x: string | undefined | null, y: string | undefined | null): number;
+    public compare(x: string | undefined | null, y: string | undefined | null) {
+        if (x === y) return 0;
+        if (!x) return -1;
+        if (!y) return +1;
+
+        x = normalizeSlashes(x);
+        x = trimTrailingDirectorySeparator(x);
+        x = removeWindowsLongPathPrefix(x);
+        // DOS drives are always case insensitive
+        x = /^[a-z]:/i.test(x) ? `${x.slice(0, 2).toUpperCase()}${x.slice(2)}` : x;
+
+        y = normalizeSlashes(y);
+        y = trimTrailingDirectorySeparator(y);
+        y = removeWindowsLongPathPrefix(y);
+        // DOS drives are always case insensitive
+        y = /^[a-z]:/i.test(y) ? `${y.slice(0, 2).toUpperCase()}${y.slice(2)}` : y;
+
+        return this._comparer.compare(x, y);
+    }
+
+    public equals(x: string, y: string): boolean;
+    public equals(x: string | undefined | null, y: string | undefined | null): boolean;
+    public equals(x: string | undefined | null, y: string | undefined | null) {
+        if (x === y) return true;
+        if (!x) return false;
+        if (!y) return false;
+
+        x = normalizeSlashes(x);
+        x = trimTrailingDirectorySeparator(x);
+        x = removeWindowsLongPathPrefix(x);
+        // DOS drives are always case insensitive
+        x = /^[a-z]:/i.test(x) ? `${x.slice(0, 2).toUpperCase()}${x.slice(2)}` : x;
+
+        y = normalizeSlashes(y);
+        y = trimTrailingDirectorySeparator(y);
+        y = removeWindowsLongPathPrefix(y);
+        // DOS drives are always case insensitive
+        y = /^[a-z]:/i.test(y) ? `${y.slice(0, 2).toUpperCase()}${y.slice(2)}` : y;
+
+        return this._comparer.equals(x, y);
+    }
+
+    public hash(x: string): number {
+        x = normalizeSlashes(x);
+        x = trimTrailingDirectorySeparator(x);
+        x = removeWindowsLongPathPrefix(x);
+        // DOS drives are always case insensitive
+        x = /^[a-z]:/i.test(x) ? `${x.slice(0, 2).toUpperCase()}${x.slice(2)}` : x;
+        return this._comparer.hash(x);
+    }
+}


### PR DESCRIPTION
Follow-on to #65, this makes `--scenarioDir` a singular option and does some additional cleanup on the `Scenario` type.