### PR TITLE
Fix ts-pre-modules to work with updated outFile buildinfo changes

### DIFF
--- a/cases/scenarios/ts-pre-modules/scenario.json
+++ b/cases/scenarios/ts-pre-modules/scenario.json
@@ -4,8 +4,10 @@
     "args": [
         "-p",
         "${suiteDirectory}/ts-pre-modules/src/compiler",
-        "--outdir",
-        "${outDirectory}"
+        "--outfile",
+        "${outDirectory}/out.js",
+        "--composite",
+        "false"
     ],
     "platforms": [
         "linux"


### PR DESCRIPTION
#58760 made outFile always emit buildinfo, which then caused this benchmark to start being "too fast" because it's actually incremental.

Testing incremental is a good idea in general, but this benchmark was not actually intended to test that, so disable composite mode and fix the flag (which should not have been outdir).