### PR TITLE
Fix blob upload identity

### DIFF
--- a/build/benchmark.yml
+++ b/build/benchmark.yml
@@ -421,7 +421,15 @@ jobs:
           azureSubscription: TsPerfStorage
           scriptType: 'bash'
           scriptLocation: 'inlineScript'
+          addSpnToEnvironment: true
           inlineScript: |
+            # Force these credentials to be used in case the pool itself has an identity (which takes priority over the CLI).
+            # https://learn.microsoft.com/en-us/azure/developer/javascript/sdk/authentication/credential-chains#use-defaultazurecredential-for-flexibility
+            # https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/identity/identity#service-principal-with-secret
+            export AZURE_CLIENT_ID="${servicePrincipalId}"
+            export AZURE_TENANT_ID="${tenantId}"
+            export AZURE_CLIENT_SECRET="${servicePrincipalKey}"
+
             set -exo pipefail
             for KIND in $(TSPERF_PROCESS_KINDS); do
               echo "Uploading ${KIND} benchmarks"


### PR DESCRIPTION
The new pool has an identity, which takes precedence over the CLI login. Force the credential by setting it in the environment instead.