### PR TITLE
line and offset are 0 based in corsa

### DIFF
--- a/build/benchmark.yml
+++ b/build/benchmark.yml
@@ -90,7 +90,7 @@ parameters:
     type: string
     default: 'any,ts-perf1,ts-perf2,ts-perf3,ts-perf4,ts-perf5,ts-perf6,ts-perf7,ts-perf8,ts-perf9,ts-perf10,ts-perf11,ts-perf12'
   - name: TS_GO
-    displayName: boolean to describe if building ts-go
+    displayName: building ts-go
     type: boolean
     default: false
 

--- a/ts-perf/packages/commands/src/benchmark/measurelsp.ts
+++ b/ts-perf/packages/commands/src/benchmark/measurelsp.ts
@@ -280,8 +280,8 @@ async function runPerf(options: CLIOpts) {
         await connection.sendRequest(protocol.ReferencesRequest.method, {
             textDocument: { uri: fileUri },
             position: {
-                line: command.args.line,
-                character: command.args.offset,
+                line: command.args.line - 1,
+                character: command.args.offset - 1,
             },
             context: { includeDeclaration: true },
         } as protocol.ReferenceParams);
@@ -307,8 +307,8 @@ async function runPerf(options: CLIOpts) {
             {
                 textDocument: { uri: fileUri },
                 position: {
-                    line: command.args.line,
-                    character: command.args.offset,
+                    line: command.args.line - 1,
+                    character: command.args.offset - 1,
                 },
             } as protocol.CompletionParams,
         );


### PR DESCRIPTION
The completions requests were exiting because they were out of bounds, because strada protocol's position used to be 1 based. 

This fixes them-- current log: https://typescript.visualstudio.com/TypeScript/_build/results?buildId=167678&view=logs&j=df337554-f460-5fd0-23d3-e432c85312d5&t=71517be0-f2ad-54f3-30bb-783563b5f319

Previous logs: https://typescript.visualstudio.com/TypeScript/_build/results?buildId=167611&view=logs&j=df337554-f460-5fd0-23d3-e432c85312d5&t=07c2bd9a-ebf1-5d82-6fcc-7f932807c6e2