### PR TITLE
Support migrated TS 7 repo

### DIFF
--- a/build/benchmark.yml
+++ b/build/benchmark.yml
@@ -109,11 +109,9 @@ variables:
   ${{ if eq(parameters.TS_GO, true) }}:
     REPO: 'typescript-go'
     REF: $[ replace(resources.repositories['typescript-go'].ref, 'heads/../', '') ]
-    TSPERF_IMPLEMENTATION: 'corsa'
   ${{ else }}:
     REPO: 'TypeScript'
     REF: $[ replace(resources.repositories['TypeScript'].ref, 'heads/../', '') ]
-    TSPERF_IMPLEMENTATION: ''
 
   PRETTY_REF: $[ replace(replace(replace(replace(variables['REF'], '/merge', ''), 'refs/pull/', 'pr.'), 'refs/heads/', ''), '/', '_') ]
   IS_PR: $[ startsWith(variables['REF'], 'refs/pull/') ]
@@ -187,8 +185,6 @@ jobs:
           node $(BENCH_SCRIPTS)/setupPipeline.js
         displayName: Setup pipeline
         name: setupPipeline
-        env:
-          TSPERF_IMPLEMENTATION: $(TSPERF_IMPLEMENTATION)
 
       - bash: |
           set -exo pipefail

--- a/build/benchmark.yml
+++ b/build/benchmark.yml
@@ -90,7 +90,7 @@ parameters:
     type: string
     default: 'any,ts-perf1,ts-perf2,ts-perf3,ts-perf4,ts-perf5,ts-perf6,ts-perf7,ts-perf8,ts-perf9,ts-perf10,ts-perf11,ts-perf12'
   - name: TS_GO
-    displayName: building ts-go
+    displayName: Use the legacy typescript-go repository
     type: boolean
     default: false
 
@@ -255,11 +255,10 @@ jobs:
             artifact: BuiltTypeScript
             displayName: Download built TypeScript
 
-          - ${{ if eq(parameters.TS_GO, true) }}:
-              - bash: |
-                  set -exo pipefail
-                  find $(BUILT_TYPESCRIPT_DIR) -name 'tsgo' -type f -exec chmod +x {} +
-                displayName: Make tsgo executable
+          - bash: |
+              set -exo pipefail
+              find $(BUILT_TYPESCRIPT_DIR) -type f \( -name 'tsgo' -o -name 'tsc' \) -exec chmod +x {} +
+            displayName: Make native TypeScript executable
 
           # This is provided by the agent.
           - bash: |

--- a/build/benchmark.yml
+++ b/build/benchmark.yml
@@ -109,11 +109,11 @@ variables:
   ${{ if eq(parameters.TS_GO, true) }}:
     REPO: 'typescript-go'
     REF: $[ replace(resources.repositories['typescript-go'].ref, 'heads/../', '') ]
-    TSGOFLAG: '--tsgo'
+    TSPERF_IMPLEMENTATION: 'corsa'
   ${{ else }}:
     REPO: 'TypeScript'
     REF: $[ replace(resources.repositories['TypeScript'].ref, 'heads/../', '') ]
-    TSGOFLAG: ''
+    TSPERF_IMPLEMENTATION: ''
 
   PRETTY_REF: $[ replace(replace(replace(replace(variables['REF'], '/merge', ''), 'refs/pull/', 'pr.'), 'refs/heads/', ''), '/', '_') ]
   IS_PR: $[ startsWith(variables['REF'], 'refs/pull/') ]
@@ -188,7 +188,7 @@ jobs:
         displayName: Setup pipeline
         name: setupPipeline
         env:
-          TSGOFLAG: $(TSGOFLAG)
+          TSPERF_IMPLEMENTATION: $(TSPERF_IMPLEMENTATION)
 
       - bash: |
           set -exo pipefail
@@ -199,7 +199,7 @@ jobs:
 
       - bash: |
           set -exo pipefail
-          node $(BENCH_SCRIPTS)/buildTypeScript.js --outputDir $(ARTIFACTS_DIR)/new $(TSGOFLAG)
+          node $(BENCH_SCRIPTS)/buildTypeScript.js --outputDir $(ARTIFACTS_DIR)/new
         displayName: Build new TypeScript
         condition: and(succeeded(), eq(variables['TSPERF_IS_COMPARISON'], 'true'))
         workingDirectory: $(TYPESCRIPT_DIR)
@@ -214,7 +214,7 @@ jobs:
 
       - bash: |
           set -exo pipefail
-          node $(BENCH_SCRIPTS)/buildTypeScript.js --baseline --outputDir $(ARTIFACTS_DIR)/baseline $(TSGOFLAG)
+          node $(BENCH_SCRIPTS)/buildTypeScript.js --baseline --outputDir $(ARTIFACTS_DIR)/baseline
         displayName: Build baseline TypeScript
         workingDirectory: $(TYPESCRIPT_DIR)
         name: buildTypeScriptBaseline
@@ -438,7 +438,7 @@ jobs:
 
       - bash: |
           set -exo pipefail
-          node $(BENCH_SCRIPTS)/postPerfResult.js --fragment $(Pipeline.Workspace)/comment.html $(TSGOFLAG)
+          node $(BENCH_SCRIPTS)/postPerfResult.js --fragment $(Pipeline.Workspace)/comment.html
         displayName: Publish PR comment
         condition: and(succeeded(), eq(variables['IS_PR'], 'true'))
         env:
@@ -535,7 +535,7 @@ jobs:
 
       - bash: |
           set -exo pipefail
-          node $(BENCH_SCRIPTS)/postPerfResult.js --failed $(TSGOFLAG)
+          node $(BENCH_SCRIPTS)/postPerfResult.js --failed
         displayName: Publish PR comment
         env:
           DISTINCT_ID: ${{ parameters.DISTINCT_ID }}

--- a/scripts/src/__tests__/setupPipeline.test.ts
+++ b/scripts/src/__tests__/setupPipeline.test.ts
@@ -57,7 +57,7 @@ test.each(inputs)("setupPipeline input=%s", async input => {
             isPr: !baselining,
             shouldLog: false,
             gitParseRev: fakeGitRevParse,
-            tsgo: false,
+            implementation: "strada",
         });
     }
     catch (e) {
@@ -71,7 +71,7 @@ test.each(inputs)("setupPipeline input=%s", async input => {
     await expect(error).toMatchFileSnapshot(getSnapshotPath(input, "error"));
 });
 
-test.each(inputs)("setupPipeline tsgo input=%s", async input => {
+test.each(inputs)("setupPipeline Corsa input=%s", async input => {
     const baselining = input === "baseline";
 
     let result, error;
@@ -82,7 +82,7 @@ test.each(inputs)("setupPipeline tsgo input=%s", async input => {
             isPr: !baselining,
             shouldLog: false,
             gitParseRev: fakeGitRevParse,
-            tsgo: true,
+            implementation: "corsa",
         });
     }
     catch (e) {

--- a/scripts/src/__tests__/typeScriptRepo.test.ts
+++ b/scripts/src/__tests__/typeScriptRepo.test.ts
@@ -1,0 +1,39 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, expect, test } from "vitest";
+
+import { detectTypeScriptImplementation } from "../typeScriptRepo.js";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+    for (const tempDir of tempDirs.splice(0)) {
+        fs.rmSync(tempDir, { recursive: true });
+    }
+});
+
+function createRepo(packageName: string, files: string[] = []) {
+    const repoDir = fs.mkdtempSync(path.join(os.tmpdir(), "typescript-benchmarking-"));
+    tempDirs.push(repoDir);
+    fs.writeFileSync(path.join(repoDir, "package.json"), JSON.stringify({ name: packageName }));
+    for (const file of files) {
+        const filePath = path.join(repoDir, file);
+        fs.mkdirSync(path.dirname(filePath), { recursive: true });
+        fs.writeFileSync(filePath, "");
+    }
+    return repoDir;
+}
+
+test("detects the JavaScript TypeScript repository", () => {
+    expect(detectTypeScriptImplementation(createRepo("typescript"))).toBe("typescript");
+});
+
+test("detects the legacy typescript-go repository", () => {
+    expect(detectTypeScriptImplementation(createRepo("typescript-go"))).toBe("tsgo");
+});
+
+test("detects the migrated Go implementation from its root package name", () => {
+    expect(detectTypeScriptImplementation(createRepo("@typescript/repo"))).toBe("tsgo");
+});

--- a/scripts/src/__tests__/typeScriptRepo.test.ts
+++ b/scripts/src/__tests__/typeScriptRepo.test.ts
@@ -26,14 +26,14 @@ function createRepo(packageName: string, files: string[] = []) {
     return repoDir;
 }
 
-test("detects the JavaScript TypeScript repository", () => {
-    expect(detectTypeScriptImplementation(createRepo("typescript"))).toBe("typescript");
+test("detects the Strada implementation", () => {
+    expect(detectTypeScriptImplementation(createRepo("typescript"))).toBe("strada");
 });
 
-test("detects the legacy typescript-go repository", () => {
-    expect(detectTypeScriptImplementation(createRepo("typescript-go"))).toBe("tsgo");
+test("detects the legacy typescript-go repository as Corsa", () => {
+    expect(detectTypeScriptImplementation(createRepo("typescript-go"))).toBe("corsa");
 });
 
-test("detects the migrated Go implementation from its root package name", () => {
-    expect(detectTypeScriptImplementation(createRepo("@typescript/repo"))).toBe("tsgo");
+test("detects the migrated Corsa implementation from its root package name", () => {
+    expect(detectTypeScriptImplementation(createRepo("@typescript/repo"))).toBe("corsa");
 });

--- a/scripts/src/buildTypeScript.ts
+++ b/scripts/src/buildTypeScript.ts
@@ -15,7 +15,7 @@ const { stdout: timestampDir } = await $pipe`date -d ${date} -u +%Y/%m/%d`;
 
 const args = minimist(process.argv.slice(2), {
     string: ["outputDir"],
-    boolean: ["baseline", "tsgo"],
+    boolean: ["baseline"],
 });
 
 const outputDir = args.outputDir;
@@ -23,14 +23,14 @@ assert(outputDir, "Expected output path as first argument");
 
 const implementation = detectTypeScriptImplementation(".");
 assert(implementation, "Expected to be run from the TypeScript repo");
-const tsgo = args.tsgo || implementation === "tsgo";
+const isCorsa = implementation === "corsa";
 
 await $`mkdir -p ${path.dirname(outputDir)}`;
 
 await retry(() => $`npm ci`);
 
 if (fs.existsSync("Herebyfile.mjs")) {
-    if (tsgo) {
+    if (isCorsa) {
         await $`npx hereby build`;
         await $`mv built/local ${outputDir}`;
     }
@@ -66,7 +66,7 @@ if (!isCustomCommitRange) {
             const octokit = new Octokit();
             const pr = await octokit.rest.pulls.get({
                 owner: "microsoft",
-                repo: process.env.REPO ?? (args.tsgo ? "typescript-go" : "TypeScript"),
+                repo: getNonEmptyEnv("REPO"),
                 pull_number: +prNumber,
             });
             branch = pr.data.base.ref;

--- a/scripts/src/buildTypeScript.ts
+++ b/scripts/src/buildTypeScript.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import minimist from "minimist";
 import { Octokit } from "octokit";
 
+import { detectTypeScriptImplementation } from "./typeScriptRepo.js";
 import { $, $pipe, getNonEmptyEnv, parseBoolean, RepoInfo, retry, setOutputVariable } from "./utils.js";
 
 const { stdout: commit } = await $pipe`git rev-parse HEAD`;
@@ -20,18 +21,16 @@ const args = minimist(process.argv.slice(2), {
 const outputDir = args.outputDir;
 assert(outputDir, "Expected output path as first argument");
 
-const packageJson = await fs.promises.readFile("package.json", "utf8");
-assert(
-    JSON.parse(packageJson).name === "typescript" || JSON.parse(packageJson).name === "typescript-go",
-    "Expected to be run from the TypeScript repo",
-);
+const implementation = detectTypeScriptImplementation(".");
+assert(implementation, "Expected to be run from the TypeScript repo");
+const tsgo = args.tsgo || implementation === "tsgo";
 
 await $`mkdir -p ${path.dirname(outputDir)}`;
 
 await retry(() => $`npm ci`);
 
 if (fs.existsSync("Herebyfile.mjs")) {
-    if (args.tsgo) {
+    if (tsgo) {
         await $`npx hereby build`;
         await $`mv built/local ${outputDir}`;
     }
@@ -67,7 +66,7 @@ if (!isCustomCommitRange) {
             const octokit = new Octokit();
             const pr = await octokit.rest.pulls.get({
                 owner: "microsoft",
-                repo: args.tsgo ? "typescript-go" : "TypeScript",
+                repo: process.env.REPO ?? (args.tsgo ? "typescript-go" : "TypeScript"),
                 pull_number: +prNumber,
             });
             branch = pr.data.base.ref;

--- a/scripts/src/postPerfResult.ts
+++ b/scripts/src/postPerfResult.ts
@@ -27,7 +27,7 @@ async function main() {
         boolean: ["failed", "tsgo"],
     });
 
-    const repo = args.tsgo ? "typescript-go" : "TypeScript";
+    const repo = process.env.REPO ?? (args.tsgo ? "typescript-go" : "TypeScript");
     const gh = new Octokit({ auth: GH_TOKEN });
     let body;
     if (args.failed) {

--- a/scripts/src/postPerfResult.ts
+++ b/scripts/src/postPerfResult.ts
@@ -24,10 +24,11 @@ async function main() {
 
     const args = minimist(process.argv.slice(2), {
         string: ["fragment"],
-        boolean: ["failed", "tsgo"],
+        boolean: ["failed"],
     });
 
-    const repo = process.env.REPO ?? (args.tsgo ? "typescript-go" : "TypeScript");
+    const repo = process.env.REPO;
+    if (!repo) throw new Error("REPO environment variable not set.");
     const gh = new Octokit({ auth: GH_TOKEN });
     let body;
     if (args.failed) {

--- a/scripts/src/setupPipeline.ts
+++ b/scripts/src/setupPipeline.ts
@@ -5,7 +5,7 @@ import esMain from "es-main";
 import prettyMilliseconds from "pretty-ms";
 import sortKeys from "sort-keys";
 
-import { detectTypeScriptImplementation } from "./typeScriptRepo.js";
+import { detectTypeScriptImplementation, TypeScriptImplementation } from "./typeScriptRepo.js";
 import { $pipe, getNonEmptyEnv, parseBoolean, setJobVariable, setOutputVariable } from "./utils.js";
 
 // Keep in sync with inventory.yml and benchmark.yml.
@@ -40,7 +40,7 @@ type BaselineAgent = Exclude<AllAgents, ReserveAgents>;
 type Agent = "any" | AllAgents;
 
 const defaultIterations = 6;
-const tsgoIterations = 12;
+const corsaIterations = 12;
 const defaultWarmups = 1;
 
 // TODO(jakebailey): have unpinned variants; ts-perf mostly supports @latest.
@@ -429,7 +429,12 @@ async function parseInput({ input, isPr, gitParseRev }: SetupPipelineInput) {
     return parsed;
 }
 
-function* transformPreset(parameters: Parameters, iter: Iterable<Scenario>, tsgo: boolean): Iterable<Scenario> {
+function* transformPreset(
+    parameters: Parameters,
+    iter: Iterable<Scenario>,
+    implementation: TypeScriptImplementation,
+): Iterable<Scenario> {
+    const isCorsa = implementation === "corsa";
     const all = [...worker()];
 
     for (const scenario of all) {
@@ -451,8 +456,8 @@ function* transformPreset(parameters: Parameters, iter: Iterable<Scenario>, tsgo
     function* worker(): Iterable<Scenario> {
         for (const scenario of iter) {
             if (
-                (tsgo && (scenario.kind === "tsserver" || scenario.name === "self-build-src-public-api"))
-                || (!tsgo && scenario.kind === "lsp")
+                (isCorsa && (scenario.kind === "tsserver" || scenario.name === "self-build-src-public-api"))
+                || (!isCorsa && scenario.kind === "lsp")
             ) {
                 continue;
             }
@@ -460,7 +465,7 @@ function* transformPreset(parameters: Parameters, iter: Iterable<Scenario>, tsgo
                 switch (scenario.name) {
                     case "tsgo-startup":
                     case "lsp-startup":
-                        if (!tsgo) {
+                        if (!isCorsa) {
                             continue;
                         }
                         break;
@@ -468,18 +473,18 @@ function* transformPreset(parameters: Parameters, iter: Iterable<Scenario>, tsgo
                     case "tsserver-startup":
                     case "tsserverlibrary-startup":
                     case "typescript-startup":
-                        if (tsgo) {
+                        if (isCorsa) {
                             continue;
                         }
                 }
             }
-            const scenarioHosts = tsgo ? [hosts.native] : (parameters.hosts ?? [scenario.host]);
+            const scenarioHosts = isCorsa ? [hosts.native] : (parameters.hosts ?? [scenario.host]);
 
             for (const host of scenarioHosts) {
                 yield {
                     ...scenario,
                     host,
-                    iterations: tsgo ? tsgoIterations : scenario.iterations,
+                    iterations: isCorsa ? corsaIterations : scenario.iterations,
                 };
             }
         }
@@ -497,13 +502,13 @@ export interface SetupPipelineInput {
     input: string;
     baselining: boolean;
     isPr: boolean;
-    tsgo: boolean;
+    implementation: TypeScriptImplementation;
     shouldLog: boolean;
     gitParseRev: (query: string) => Promise<GitParseRevResult>;
 }
 
 export async function setupPipeline(input: SetupPipelineInput) {
-    const { baselining, shouldLog, tsgo } = input;
+    const { baselining, implementation, shouldLog } = input;
 
     const parameters = await parseInput(input);
     if (shouldLog) {
@@ -535,7 +540,7 @@ export async function setupPipeline(input: SetupPipelineInput) {
     let maxCost = 0;
     const costPerAgent = new Map<Agent, number>();
 
-    for (const scenario of transformPreset(parameters, preset(), tsgo)) {
+    for (const scenario of transformPreset(parameters, preset(), implementation)) {
         const agent = baselining ? scenario.agent : "any";
         const jobName = sanitizeJobName(`${scenario.kind}_${scenario.host}_${scenario.name}`);
         matrix[agent][jobName] = {
@@ -657,16 +662,27 @@ if (esMain(import.meta)) {
     const baselining = parseBoolean(process.env.USE_BASELINE_MACHINE, false);
     const isPr = parseBoolean(process.env.IS_PR, false);
     const typescriptDir = getNonEmptyEnv("TYPESCRIPT_DIR");
-    const implementation = detectTypeScriptImplementation(typescriptDir);
-    assert(implementation, `Expected ${typescriptDir} to contain a TypeScript repository`);
-    const tsgo = !!process.env.TSGOFLAG || implementation === "tsgo";
-    setJobVariable("TSGOFLAG", tsgo ? "--tsgo" : "");
+    const detectedImplementation = detectTypeScriptImplementation(typescriptDir);
+    assert(detectedImplementation, `Expected ${typescriptDir} to contain a TypeScript repository`);
+    const requestedImplementation = process.env.TSPERF_IMPLEMENTATION;
+    let implementation = detectedImplementation;
+    if (requestedImplementation) {
+        switch (requestedImplementation) {
+            case "strada":
+            case "corsa":
+                implementation = requestedImplementation;
+                break;
+            default:
+                assert.fail(`Unexpected TSPERF_IMPLEMENTATION: ${requestedImplementation}`);
+        }
+    }
+    setJobVariable("TSPERF_IMPLEMENTATION", implementation);
 
     const { outputVariables } = await setupPipeline({
         input,
         baselining,
         isPr,
-        tsgo,
+        implementation,
         shouldLog: true,
         gitParseRev,
     });

--- a/scripts/src/setupPipeline.ts
+++ b/scripts/src/setupPipeline.ts
@@ -662,21 +662,8 @@ if (esMain(import.meta)) {
     const baselining = parseBoolean(process.env.USE_BASELINE_MACHINE, false);
     const isPr = parseBoolean(process.env.IS_PR, false);
     const typescriptDir = getNonEmptyEnv("TYPESCRIPT_DIR");
-    const detectedImplementation = detectTypeScriptImplementation(typescriptDir);
-    assert(detectedImplementation, `Expected ${typescriptDir} to contain a TypeScript repository`);
-    const requestedImplementation = process.env.TSPERF_IMPLEMENTATION;
-    let implementation = detectedImplementation;
-    if (requestedImplementation) {
-        switch (requestedImplementation) {
-            case "strada":
-            case "corsa":
-                implementation = requestedImplementation;
-                break;
-            default:
-                assert.fail(`Unexpected TSPERF_IMPLEMENTATION: ${requestedImplementation}`);
-        }
-    }
-    setJobVariable("TSPERF_IMPLEMENTATION", implementation);
+    const implementation = detectTypeScriptImplementation(typescriptDir);
+    assert(implementation, `Expected ${typescriptDir} to contain a TypeScript repository`);
 
     const { outputVariables } = await setupPipeline({
         input,

--- a/scripts/src/setupPipeline.ts
+++ b/scripts/src/setupPipeline.ts
@@ -5,6 +5,7 @@ import esMain from "es-main";
 import prettyMilliseconds from "pretty-ms";
 import sortKeys from "sort-keys";
 
+import { detectTypeScriptImplementation } from "./typeScriptRepo.js";
 import { $pipe, getNonEmptyEnv, parseBoolean, setJobVariable, setOutputVariable } from "./utils.js";
 
 // Keep in sync with inventory.yml and benchmark.yml.
@@ -655,7 +656,11 @@ if (esMain(import.meta)) {
     const input = getNonEmptyEnv("TSPERF_PRESET");
     const baselining = parseBoolean(process.env.USE_BASELINE_MACHINE, false);
     const isPr = parseBoolean(process.env.IS_PR, false);
-    const tsgo = !!process.env.TSGOFLAG;
+    const typescriptDir = getNonEmptyEnv("TYPESCRIPT_DIR");
+    const implementation = detectTypeScriptImplementation(typescriptDir);
+    assert(implementation, `Expected ${typescriptDir} to contain a TypeScript repository`);
+    const tsgo = !!process.env.TSGOFLAG || implementation === "tsgo";
+    setJobVariable("TSGOFLAG", tsgo ? "--tsgo" : "");
 
     const { outputVariables } = await setupPipeline({
         input,

--- a/scripts/src/typeScriptRepo.ts
+++ b/scripts/src/typeScriptRepo.ts
@@ -1,0 +1,16 @@
+import fs from "node:fs";
+import path from "node:path";
+
+export type TypeScriptImplementation = "typescript" | "tsgo";
+
+export function detectTypeScriptImplementation(repoDir: string): TypeScriptImplementation | undefined {
+    const packageJsonPath = path.join(repoDir, "package.json");
+    if (!fs.existsSync(packageJsonPath)) {
+        return undefined;
+    }
+
+    const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
+    return typeof packageJson.name === "string"
+        ? packageJson.name === "typescript" ? "typescript" : "tsgo"
+        : undefined;
+}

--- a/scripts/src/typeScriptRepo.ts
+++ b/scripts/src/typeScriptRepo.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 
-export type TypeScriptImplementation = "typescript" | "tsgo";
+export type TypeScriptImplementation = "strada" | "corsa";
 
 export function detectTypeScriptImplementation(repoDir: string): TypeScriptImplementation | undefined {
     const packageJsonPath = path.join(repoDir, "package.json");
@@ -11,6 +11,6 @@ export function detectTypeScriptImplementation(repoDir: string): TypeScriptImple
 
     const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
     return typeof packageJson.name === "string"
-        ? packageJson.name === "typescript" ? "typescript" : "tsgo"
+        ? packageJson.name === "typescript" ? "strada" : "corsa"
         : undefined;
 }

--- a/ts-perf/packages/commands/src/benchmark/lspServerCommand.ts
+++ b/ts-perf/packages/commands/src/benchmark/lspServerCommand.ts
@@ -1,0 +1,17 @@
+export function getLspServerCommand(
+    lspServerPath: string,
+    serverArgs: readonly string[],
+    cpus: string | undefined,
+    platform = process.platform,
+) {
+    if (!cpus) {
+        return { command: lspServerPath, args: [...serverArgs] };
+    }
+    if (platform !== "linux") {
+        throw new Error("--cpus only works on Linux");
+    }
+    return {
+        command: "taskset",
+        args: ["--cpu-list", cpus, lspServerPath, ...serverArgs],
+    };
+}

--- a/ts-perf/packages/commands/src/benchmark/measure.ts
+++ b/ts-perf/packages/commands/src/benchmark/measure.ts
@@ -305,7 +305,7 @@ async function runTSServerScenario(
     if (options.extended) {
         argsBuilder.add("--extended");
     }
-    if (options.cpus && !process.env.TSGOFLAG) {
+    if (options.cpus) {
         argsBuilder.add("--cpus", options.cpus);
     }
     if (options.predictable) {
@@ -405,7 +405,7 @@ async function runLSPScenario(
     if (options.extended) {
         argsBuilder.add("--extended");
     }
-    if (options.cpus && !process.env.TSGOFLAG) {
+    if (options.cpus) {
         argsBuilder.add("--cpus", options.cpus);
     }
     const { cmd, args } = argsBuilder;

--- a/ts-perf/packages/commands/src/benchmark/measure.ts
+++ b/ts-perf/packages/commands/src/benchmark/measure.ts
@@ -52,17 +52,21 @@ function tryParseDiagnostic(line: string) {
     return undefined;
 }
 
-function resolveBuiltPath(builtDir: string, name: string): string {
+export function resolveBuiltPath(builtDir: string, name: string): string {
     const jsPath = path.join(builtDir, `${name}.js`);
     if (fs.existsSync(jsPath)) {
         return jsPath;
     }
-    // typescript-go produces a native binary named tsgo/tsgo.exe instead of .js files.
-    for (const candidate of ["tsgo", "tsgo.exe"]) {
-        const nativePath = path.join(builtDir, candidate);
-        if (fs.existsSync(nativePath)) {
-            return nativePath;
+
+    const nativeNames = name === "tsc" ? ["tsc", "tsgo"] : name === "tsgo" ? ["tsgo", "tsc"] : [name];
+    for (const nativeName of nativeNames) {
+        const candidates = [nativeName, `${nativeName}.exe`];
+        const candidate = candidates.find(candidate => fs.existsSync(path.join(builtDir, candidate)));
+        if (!candidate) {
+            continue;
         }
+        const nativePath = path.join(builtDir, candidate);
+        return nativePath;
     }
     return "";
 }

--- a/ts-perf/packages/commands/src/benchmark/measure.ts
+++ b/ts-perf/packages/commands/src/benchmark/measure.ts
@@ -33,6 +33,7 @@ import {
 import { getTempDirectories, HostContext, ProcessExitError, SystemInfo } from "@ts-perf/core";
 
 import { BenchmarkOptions, TSOptions } from "./";
+import { resolveBuiltPath } from "./resolveBuiltPath";
 
 const diagnosticPattern = /^([a-z].+):\s+(.+?)[sk]?$/i;
 // Explicitly loose regex so --pretty will work.
@@ -50,25 +51,6 @@ function tryParseDiagnostic(line: string) {
         return { name, value: +value, precision };
     }
     return undefined;
-}
-
-export function resolveBuiltPath(builtDir: string, name: string): string {
-    const jsPath = path.join(builtDir, `${name}.js`);
-    if (fs.existsSync(jsPath)) {
-        return jsPath;
-    }
-
-    const nativeNames = name === "tsc" ? ["tsc", "tsgo"] : name === "tsgo" ? ["tsgo", "tsc"] : [name];
-    for (const nativeName of nativeNames) {
-        const candidates = [nativeName, `${nativeName}.exe`];
-        const candidate = candidates.find(candidate => fs.existsSync(path.join(builtDir, candidate)));
-        if (!candidate) {
-            continue;
-        }
-        const nativePath = path.join(builtDir, candidate);
-        return nativePath;
-    }
-    return "";
 }
 
 export async function measureAndRunScenarios({ kind, options }: TSOptions, host: HostContext): Promise<Benchmark> {

--- a/ts-perf/packages/commands/src/benchmark/measurelsp.ts
+++ b/ts-perf/packages/commands/src/benchmark/measurelsp.ts
@@ -18,6 +18,8 @@ import { CommandLine, CommandLineParseError } from "power-options";
 import * as rpc from "vscode-jsonrpc/node";
 import * as protocol from "vscode-languageserver-protocol";
 
+import { getLspServerCommand } from "./lspServerCommand.js";
+
 main().catch(e => {
     console.error(e);
     process.exit(2);
@@ -28,6 +30,7 @@ interface CLIOpts {
     commands: string;
     suite: string;
     extended?: boolean;
+    cpus?: string;
 }
 
 async function main() {
@@ -63,6 +66,10 @@ async function main() {
             extended: {
                 type: "boolean",
                 description: "If the scenario declares optional (aka extended) requests, run those as well",
+            },
+            cpus: {
+                type: "string",
+                description: "CPUs to run benchmarked processes on; see the --cpu-list in 'man taskset'",
             },
         },
         exec: ({ options }) => runPerf(options),
@@ -109,8 +116,9 @@ async function runPerf(options: CLIOpts) {
     process.chdir(solution);
 
     const serverArgs: string[] = ["--lsp", "--stdio"];
+    const { command, args } = getLspServerCommand(lspServerPath, serverArgs, options.cpus);
 
-    const serverProc = cp.spawn(lspServerPath, serverArgs, {
+    const serverProc = cp.spawn(command, args, {
         stdio: ["pipe", "pipe", "ignore"],
     });
 

--- a/ts-perf/packages/commands/src/benchmark/resolveBuiltPath.ts
+++ b/ts-perf/packages/commands/src/benchmark/resolveBuiltPath.ts
@@ -1,0 +1,20 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+export function resolveBuiltPath(builtDir: string, name: string): string {
+    const jsPath = path.join(builtDir, `${name}.js`);
+    if (fs.existsSync(jsPath)) {
+        return jsPath;
+    }
+
+    const nativeNames = name === "tsc" ? ["tsc", "tsgo"] : name === "tsgo" ? ["tsgo", "tsc"] : [name];
+    for (const nativeName of nativeNames) {
+        const candidates = [nativeName, `${nativeName}.exe`];
+        const candidate = candidates.find(candidate => fs.existsSync(path.join(builtDir, candidate)));
+        if (!candidate) {
+            continue;
+        }
+        return path.join(builtDir, candidate);
+    }
+    return "";
+}

--- a/ts-perf/packages/commands/test/lspServerCommand.test.ts
+++ b/ts-perf/packages/commands/test/lspServerCommand.test.ts
@@ -1,0 +1,21 @@
+import { expect, test } from "vitest";
+
+import { getLspServerCommand } from "../src/benchmark/lspServerCommand.js";
+
+test("runs the LSP server directly without CPU affinity", () => {
+    expect(getLspServerCommand("/path/to/tsc", ["--lsp", "--stdio"], undefined)).toEqual({
+        command: "/path/to/tsc",
+        args: ["--lsp", "--stdio"],
+    });
+});
+
+test("runs the LSP server through taskset with CPU affinity", () => {
+    expect(getLspServerCommand("/path/to/tsc", ["--lsp", "--stdio"], "2-3", "linux")).toEqual({
+        command: "taskset",
+        args: ["--cpu-list", "2-3", "/path/to/tsc", "--lsp", "--stdio"],
+    });
+});
+
+test("rejects CPU affinity on unsupported platforms", () => {
+    expect(() => getLspServerCommand("/path/to/tsc", [], "2-3", "win32")).toThrow("--cpus only works on Linux");
+});

--- a/ts-perf/packages/commands/test/measure.test.ts
+++ b/ts-perf/packages/commands/test/measure.test.ts
@@ -1,0 +1,38 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, expect, test } from "vitest";
+
+import { resolveBuiltPath } from "../src/benchmark/measure.js";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+    for (const tempDir of tempDirs.splice(0)) {
+        fs.rmSync(tempDir, { recursive: true });
+    }
+});
+
+function createBuiltDir(file: string) {
+    const builtDir = fs.mkdtempSync(path.join(os.tmpdir(), "typescript-benchmarking-"));
+    tempDirs.push(builtDir);
+    fs.writeFileSync(path.join(builtDir, file), "");
+    return builtDir;
+}
+
+test("resolves the JavaScript compiler", () => {
+    const builtDir = createBuiltDir("tsc.js");
+    expect(resolveBuiltPath(builtDir, "tsc")).toBe(path.join(builtDir, "tsc.js"));
+});
+
+test("resolves the legacy tsgo compiler", () => {
+    const builtDir = createBuiltDir("tsgo");
+    expect(resolveBuiltPath(builtDir, "tsc")).toBe(path.join(builtDir, "tsgo"));
+});
+
+test("resolves the migrated native compiler for compiler and LSP scenarios", () => {
+    const builtDir = createBuiltDir("tsc");
+    expect(resolveBuiltPath(builtDir, "tsc")).toBe(path.join(builtDir, "tsc"));
+    expect(resolveBuiltPath(builtDir, "tsgo")).toBe(path.join(builtDir, "tsc"));
+});

--- a/ts-perf/packages/commands/test/measure.test.ts
+++ b/ts-perf/packages/commands/test/measure.test.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 
 import { afterEach, expect, test } from "vitest";
 
-import { resolveBuiltPath } from "../src/benchmark/measure.js";
+import { resolveBuiltPath } from "../src/benchmark/resolveBuiltPath.js";
 
 const tempDirs: string[] = [];
 

--- a/ts-perf/packages/commands/vitest.config.mjs
+++ b/ts-perf/packages/commands/vitest.config.mjs
@@ -1,0 +1,7 @@
+import { configDefaults, defineConfig } from "vitest/config";
+
+export default defineConfig({
+    test: {
+        exclude: [...configDefaults.exclude, "**/dist/**"],
+    },
+});

--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -5,6 +5,7 @@ export default defineConfig({
         projects: [
             "scripts",
             "ts-perf/packages/api",
+            "ts-perf/packages/commands",
             // "ts-perf",
             // "ts-perf/packages/*",
         ],


### PR DESCRIPTION
Detect tsgo mode from the checked-out TypeScript repository root package name so migrated TypeScript refs automatically use native benchmark scenarios and builds.

Also supports the migrated `built/local/tsc` executable while preserving legacy `typescript-go` behavior and keeping GitHub operations targeted at the actual source repository.

Tests: `pnpm test -- --run`; `pnpm run build`